### PR TITLE
chromium: fix xnnpack patches and add readme

### DIFF
--- a/chromium/README.md
+++ b/chromium/README.md
@@ -1,0 +1,44 @@
+# Development Guide
+
+1. Export the full version string (e.g. `export VERSION=142.0.7444.134`).
+2. Download the Chromium tarball
+
+   `wget https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${VERSION}.tar.xz`
+
+3. Extract two identical working copies
+
+   ```
+   mkdir a b
+   tar -xf chromium-${VERSION}.tar.xz -C a --strip-components=1
+   tar -xf chromium-${VERSION}.tar.xz -C b --strip-components=1
+   ```
+
+4. Apply and update all patches in the `b` tree.
+5. For XNNPACK, regenerate `third_party/xnnpack/BUILD.gn` (see below).
+6. Create the patch
+
+   `diff -purN -X exclude a b > chromium-${VERSION}.diff`
+
+7. Post-process
+
+   ```
+   python3 format.py chromium-${VERSION}.diff
+   python3 split.py
+   ```
+
+# Regenerating XNNPACK’s BUILD.gn
+
+1. Start a container with Bazel 8.5.0, e.g.
+   `docker run -it --rm -v $(pwd):/src gcr.io/bazel-public/bazel:8.5.0 bash`
+
+2. Inside the container
+
+   ```
+   cd /src/third_party/xnnpack
+   BAZEL_PATH_OVERRIDE=/usr/local/bin/bazel python3 generate_build_gn.py
+   ```
+
+3. If `git cl format` fails, format the file manually:
+
+   `../../buildtools/linux64/gn format BUILD.gn`
+

--- a/chromium/chromium-142.0.7444.134.4008-loongarch64-xnnpack.diff
+++ b/chromium/chromium-142.0.7444.134.4008-loongarch64-xnnpack.diff
@@ -1,8 +1,8 @@
 diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/xnnpack/BUILD.gn b/third_party/xnnpack/BUILD.gn
 --- a/third_party/xnnpack/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
 +++ b/third_party/xnnpack/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
-@@ -1534,6 +1534,22 @@ if (current_cpu == "x64" || current_cpu
-       ":xx-transposev_arm64_standalone",
+@@ -1884,6 +1884,262 @@ if (current_cpu == "x64" || current_cpu
+       ":xx-transposev_riscv64_standalone",
      ]
    }
 +} else if (current_cpu == "loong64") {
@@ -10,7 +10,127 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/th
 +    xnnpack_deps = [
 +      ":configs_loong64",
 +      ":enums_loong64",
++      ":f16-f32-vcvt_loong64",
++      ":f16-qs8-vcvt_loong64",
++      ":f16-qu8-vcvt_loong64",
++      ":f16-rdminmax_loong64",
++      ":f16-rminmax_loong64",
++      ":f16-vapproxgelu_loong64",
++      ":f16-vcos_loong64",
++      ":f16-vexp_loong64",
++      ":f16-vgelu_loong64",
++      ":f16-vsin_loong64",
++      ":f32-argmaxpool_loong64",
++      ":f32-avgpool_loong64",
++      ":f32-conv-hwc2chw_loong64",
++      ":f32-dwconv2d-chw_loong64",
++      ":f32-dwconv_loong64",
++      ":f32-f16-vcvt_loong64",
++      ":f32-gemm_loong64",
++      ":f32-ibilinear-chw_loong64",
++      ":f32-ibilinear_loong64",
++      ":f32-igemm_loong64",
++      ":f32-maxpool_loong64",
++      ":f32-qc4w-gemm_loong64",
++      ":f32-qc8w-gemm_loong64",
++      ":f32-qs8-vcvt_loong64",
++      ":f32-qu8-vcvt_loong64",
++      ":f32-raddstoreexpminusmax_loong64",
++      ":f32-rdminmax_loong64",
++      ":f32-rdsum2_loong64",
++      ":f32-rdsum_loong64",
++      ":f32-rminmax_loong64",
++      ":f32-rsum2_loong64",
++      ":f32-rsum_loong64",
++      ":f32-spmm_loong64",
++      ":f32-vapproxgelu_loong64",
++      ":f32-vbinary_loong64",
++      ":f32-vclamp_loong64",
++      ":f32-vcmul_loong64",
++      ":f32-vcopysign_loong64",
++      ":f32-vcos_loong64",
++      ":f32-velu_loong64",
++      ":f32-vexp_loong64",
++      ":f32-vgelu_loong64",
++      ":f32-vhswish_loong64",
++      ":f32-vlog_loong64",
++      ":f32-vlrelu_loong64",
++      ":f32-vmulcaddc_loong64",
++      ":f32-vrnd_loong64",
++      ":f32-vrsqrt_loong64",
++      ":f32-vsigmoid_loong64",
++      ":f32-vsin_loong64",
++      ":f32-vsqrt_loong64",
++      ":f32-vtanh_loong64",
++      ":f32-vunary_loong64",
 +      ":operators_loong64",
++      ":qd8-f32-qb4w-gemm_loong64",
++      ":qd8-f32-qc4w-gemm_loong64",
++      ":qd8-f32-qc8w-gemm_loong64",
++      ":qd8-f32-qc8w-igemm_loong64",
++      ":qs8-dwconv_loong64",
++      ":qs8-f32-vcvt_loong64",
++      ":qs8-packw_loong64",
++      ":qs8-qc4w-gemm_loong64",
++      ":qs8-qc8w-dwconv_loong64",
++      ":qs8-qc8w-gemm_loong64",
++      ":qs8-qc8w-igemm_loong64",
++      ":qs8-qu8-packw_loong64",
++      ":qs8-rdsum_loong64",
++      ":qs8-rsum_loong64",
++      ":qs8-vadd_loong64",
++      ":qs8-vaddc_loong64",
++      ":qs8-vcvt_loong64",
++      ":qs8-vlrelu_loong64",
++      ":qs8-vmul_loong64",
++      ":qs8-vmulc_loong64",
++      ":qs8-vprelu_loong64",
++      ":qs8-vpreluc_loong64",
++      ":qs8-vrpreluc_loong64",
++      ":qu8-dwconv_loong64",
++      ":qu8-f32-vcvt_loong64",
++      ":qu8-gemm_loong64",
++      ":qu8-igemm_loong64",
++      ":qu8-rdsum_loong64",
++      ":qu8-rsum_loong64",
++      ":qu8-vadd_loong64",
++      ":qu8-vaddc_loong64",
++      ":qu8-vcvt_loong64",
++      ":qu8-vlrelu_loong64",
++      ":qu8-vmul_loong64",
++      ":qu8-vmulc_loong64",
++      ":qu8-vprelu_loong64",
++      ":qu8-vpreluc_loong64",
++      ":qu8-vrpreluc_loong64",
++      ":reference_loong64",
++      ":s8-ibilinear_loong64",
++      ":s8-maxpool_loong64",
++      ":s8-rdminmax_loong64",
++      ":s8-rminmax_loong64",
++      ":s8-vclamp_loong64",
++      ":subgraph_loong64",
++      ":tables_loong64",
++      ":u8-ibilinear_loong64",
++      ":u8-lut32norm_loong64",
++      ":u8-maxpool_loong64",
++      ":u8-rdminmax_loong64",
++      ":u8-rminmax_loong64",
++      ":u8-vclamp_loong64",
++      ":x16-transposec_loong64",
++      ":x16-x32-packw_loong64",
++      ":x24-transposec_loong64",
++      ":x32-packw_loong64",
++      ":x32-transposec_loong64",
++      ":x32-unpool_loong64",
++      ":x64-transposec_loong64",
++      ":x8-lut_loong64",
++      ":x8-packq_loong64",
++      ":x8-packw_loong64",
++      ":x8-transposec_loong64",
++      ":xx-copy_loong64",
++      ":xx-fill_loong64",
++      ":xx-pad_loong64",
++      ":xx-transposev_loong64",
 +    ]
 +  }
 +
@@ -18,16 +138,141 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/th
 +    xnnpack_standalone_deps = [
 +      ":configs_loong64_standalone",
 +      ":enums_loong64_standalone",
++      ":f16-f32-vcvt_loong64_standalone",
++      ":f16-qs8-vcvt_loong64_standalone",
++      ":f16-qu8-vcvt_loong64_standalone",
++      ":f16-rdminmax_loong64_standalone",
++      ":f16-rminmax_loong64_standalone",
++      ":f16-vapproxgelu_loong64_standalone",
++      ":f16-vcos_loong64_standalone",
++      ":f16-vexp_loong64_standalone",
++      ":f16-vgelu_loong64_standalone",
++      ":f16-vsin_loong64_standalone",
++      ":f32-argmaxpool_loong64_standalone",
++      ":f32-avgpool_loong64_standalone",
++      ":f32-conv-hwc2chw_loong64_standalone",
++      ":f32-dwconv2d-chw_loong64_standalone",
++      ":f32-dwconv_loong64_standalone",
++      ":f32-f16-vcvt_loong64_standalone",
++      ":f32-gemm_loong64_standalone",
++      ":f32-ibilinear-chw_loong64_standalone",
++      ":f32-ibilinear_loong64_standalone",
++      ":f32-igemm_loong64_standalone",
++      ":f32-maxpool_loong64_standalone",
++      ":f32-qc4w-gemm_loong64_standalone",
++      ":f32-qc8w-gemm_loong64_standalone",
++      ":f32-qs8-vcvt_loong64_standalone",
++      ":f32-qu8-vcvt_loong64_standalone",
++      ":f32-raddstoreexpminusmax_loong64_standalone",
++      ":f32-rdminmax_loong64_standalone",
++      ":f32-rdsum2_loong64_standalone",
++      ":f32-rdsum_loong64_standalone",
++      ":f32-rminmax_loong64_standalone",
++      ":f32-rsum2_loong64_standalone",
++      ":f32-rsum_loong64_standalone",
++      ":f32-spmm_loong64_standalone",
++      ":f32-vapproxgelu_loong64_standalone",
++      ":f32-vbinary_loong64_standalone",
++      ":f32-vclamp_loong64_standalone",
++      ":f32-vcmul_loong64_standalone",
++      ":f32-vcopysign_loong64_standalone",
++      ":f32-vcos_loong64_standalone",
++      ":f32-velu_loong64_standalone",
++      ":f32-vexp_loong64_standalone",
++      ":f32-vgelu_loong64_standalone",
++      ":f32-vhswish_loong64_standalone",
++      ":f32-vlog_loong64_standalone",
++      ":f32-vlrelu_loong64_standalone",
++      ":f32-vmulcaddc_loong64_standalone",
++      ":f32-vrnd_loong64_standalone",
++      ":f32-vrsqrt_loong64_standalone",
++      ":f32-vsigmoid_loong64_standalone",
++      ":f32-vsin_loong64_standalone",
++      ":f32-vsqrt_loong64_standalone",
++      ":f32-vtanh_loong64_standalone",
++      ":f32-vunary_loong64_standalone",
 +      ":operators_loong64_standalone",
++      ":qd8-f32-qb4w-gemm_loong64_standalone",
++      ":qd8-f32-qc4w-gemm_loong64_standalone",
++      ":qd8-f32-qc8w-gemm_loong64_standalone",
++      ":qd8-f32-qc8w-igemm_loong64_standalone",
++      ":qs8-dwconv_loong64_standalone",
++      ":qs8-f32-vcvt_loong64_standalone",
++      ":qs8-packw_loong64_standalone",
++      ":qs8-qc4w-gemm_loong64_standalone",
++      ":qs8-qc8w-dwconv_loong64_standalone",
++      ":qs8-qc8w-gemm_loong64_standalone",
++      ":qs8-qc8w-igemm_loong64_standalone",
++      ":qs8-qu8-packw_loong64_standalone",
++      ":qs8-rdsum_loong64_standalone",
++      ":qs8-rsum_loong64_standalone",
++      ":qs8-vadd_loong64_standalone",
++      ":qs8-vaddc_loong64_standalone",
++      ":qs8-vcvt_loong64_standalone",
++      ":qs8-vlrelu_loong64_standalone",
++      ":qs8-vmul_loong64_standalone",
++      ":qs8-vmulc_loong64_standalone",
++      ":qs8-vprelu_loong64_standalone",
++      ":qs8-vpreluc_loong64_standalone",
++      ":qs8-vrpreluc_loong64_standalone",
++      ":qu8-dwconv_loong64_standalone",
++      ":qu8-f32-vcvt_loong64_standalone",
++      ":qu8-gemm_loong64_standalone",
++      ":qu8-igemm_loong64_standalone",
++      ":qu8-rdsum_loong64_standalone",
++      ":qu8-rsum_loong64_standalone",
++      ":qu8-vadd_loong64_standalone",
++      ":qu8-vaddc_loong64_standalone",
++      ":qu8-vcvt_loong64_standalone",
++      ":qu8-vlrelu_loong64_standalone",
++      ":qu8-vmul_loong64_standalone",
++      ":qu8-vmulc_loong64_standalone",
++      ":qu8-vprelu_loong64_standalone",
++      ":qu8-vpreluc_loong64_standalone",
++      ":qu8-vrpreluc_loong64_standalone",
++      ":reference_loong64_standalone",
++      ":s8-ibilinear_loong64_standalone",
++      ":s8-maxpool_loong64_standalone",
++      ":s8-rdminmax_loong64_standalone",
++      ":s8-rminmax_loong64_standalone",
++      ":s8-vclamp_loong64_standalone",
++      ":subgraph_loong64_standalone",
++      ":tables_loong64_standalone",
++      ":u8-ibilinear_loong64_standalone",
++      ":u8-lut32norm_loong64_standalone",
++      ":u8-maxpool_loong64_standalone",
++      ":u8-rdminmax_loong64_standalone",
++      ":u8-rminmax_loong64_standalone",
++      ":u8-vclamp_loong64_standalone",
++      ":x16-transposec_loong64_standalone",
++      ":x16-x32-packw_loong64_standalone",
++      ":x24-transposec_loong64_standalone",
++      ":x32-packw_loong64_standalone",
++      ":x32-transposec_loong64_standalone",
++      ":x32-unpool_loong64_standalone",
++      ":x64-transposec_loong64_standalone",
++      ":x8-lut_loong64_standalone",
++      ":x8-packq_loong64_standalone",
++      ":x8-packw_loong64_standalone",
++      ":x8-transposec_loong64_standalone",
++      ":xx-copy_loong64_standalone",
++      ":xx-fill_loong64_standalone",
++      ":xx-pad_loong64_standalone",
++      ":xx-transposev_loong64_standalone",
 +    ]
 +  }
- } else if (current_cpu == "riscv64") {
-   if (build_with_chromium) {
-     xnnpack_deps = [
-@@ -48112,6 +48128,267 @@ if (current_cpu == "arm64") {
-       ]
+ } else {
+   xnnpack_deps = []
+   if (build_with_internal_optimization_guide) {
+@@ -58223,6 +58479,7167 @@ if (current_cpu == "riscv64") {
+       cflags = []
  
-       configs -= [ "//build/config/compiler:chromium_code" ]
+       sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-transposev/xx-transposev-1x1-scalar-memcpy.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
 +      configs += [ "//build/config/compiler:no_chromium_code" ]
 +      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
 +      configs += [ ":xnnpack_private_config" ]
@@ -151,6 +396,3120 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/th
 +  }
 +
 +  if (build_with_chromium) {
++    source_set("enums_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/enums/allocation-type.c",
++        "src/src/enums/datatype-strings.c",
++        "src/src/enums/microkernel-type.c",
++        "src/src/enums/node-type.c",
++        "src/src/enums/operator-type.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("enums_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/enums/allocation-type.c",
++        "src/src/enums/datatype-strings.c",
++        "src/src/enums/microkernel-type.c",
++        "src/src/enums/node-type.c",
++        "src/src/enums/operator-type.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-f32-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-f32-vcvt/gen/f16-f32-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-f32-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-f32-vcvt/gen/f16-f32-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-qs8-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-qs8-vcvt/gen/f16-qs8-vcvt-scalar-imagic-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-qs8-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-qs8-vcvt/gen/f16-qs8-vcvt-scalar-imagic-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-qu8-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-qu8-vcvt/gen/f16-qu8-vcvt-scalar-imagic-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-qu8-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-qu8-vcvt/gen/f16-qu8-vcvt-scalar-imagic-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-rdminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-rdminmax/gen/f16-rdmax-2p2x-scalar-u2.c",
++        "src/src/f16-rdminmax/gen/f16-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-rdminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-rdminmax/gen/f16-rdmax-2p2x-scalar-u2.c",
++        "src/src/f16-rdminmax/gen/f16-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-rminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-rminmax/gen/f16-rmax-scalar-u2-acc2.c",
++        "src/src/f16-rminmax/gen/f16-rmin-scalar-u2-acc2.c",
++        "src/src/f16-rminmax/gen/f16-rminmax-scalar-u2-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-rminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-rminmax/gen/f16-rmax-scalar-u2-acc2.c",
++        "src/src/f16-rminmax/gen/f16-rmin-scalar-u2-acc2.c",
++        "src/src/f16-rminmax/gen/f16-rminmax-scalar-u2-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-vapproxgelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vapproxgelu/gen/f16-vapproxgelu-scalar-rational-6-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-vapproxgelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vapproxgelu/gen/f16-vapproxgelu-scalar-rational-6-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-vcos_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vcos/gen/f16-vcos-scalar-rational-3-2-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-vcos_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vcos/gen/f16-vcos-scalar-rational-3-2-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-vexp_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vexp/gen/f16-vexp-scalar-poly-3.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-vexp_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vexp/gen/f16-vexp-scalar-poly-3.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-vgelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vgelu/gen/f16-vgelu-scalar-rational-6-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-vgelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vgelu/gen/f16-vgelu-scalar-rational-6-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-vsin_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vsin/gen/f16-vsin-scalar-rational-3-2-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-vsin_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vsin/gen/f16-vsin-scalar-rational-3-2-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-argmaxpool_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-argmaxpool/f32-argmaxpool-9p8x-scalar-c1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-argmaxpool_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-argmaxpool/f32-argmaxpool-9p8x-scalar-c1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-avgpool_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-avgpool/gen/f32-avgpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-avgpool_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-avgpool/gen/f32-avgpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-conv-hwc2chw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-conv-hwc2chw/f32-conv-hwc2chw-3x3s2p1c3x4-scalar-1x1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-conv-hwc2chw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-conv-hwc2chw/f32-conv-hwc2chw-3x3s2p1c3x4-scalar-1x1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-dwconv2d-chw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3p1-minmax-scalar-2x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3p1-minmax-scalar-4x1.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3s2p1-minmax-scalar-1x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3s2p1-minmax-scalar-2x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5p2-minmax-scalar-1x1-acc5.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5p2-minmax-scalar-2x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5s2p2-minmax-scalar-1x1-acc5.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5s2p2-minmax-scalar-2x1-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-dwconv2d-chw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3p1-minmax-scalar-2x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3p1-minmax-scalar-4x1.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3s2p1-minmax-scalar-1x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3s2p1-minmax-scalar-2x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5p2-minmax-scalar-1x1-acc5.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5p2-minmax-scalar-2x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5s2p2-minmax-scalar-1x1-acc5.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5s2p2-minmax-scalar-2x1-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-dwconv_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p1c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p2c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p2c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-3p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-3p1c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-4p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-4p1c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-9p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-9p1c-scalar-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-dwconv_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p1c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p2c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p2c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-3p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-3p1c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-4p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-4p1c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-9p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-9p1c-scalar-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-f16-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-f16-vcvt/gen/f32-f16-vcvt-scalar-fabsf-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-f16-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-f16-vcvt/gen/f32-f16-vcvt-scalar-fabsf-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-gemm/gen/f32-gemm-1x4-minmax-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-1x4-relu-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-1x4-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x2-minmax-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x2-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x4-minmax-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x4-relu-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x4-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-gemm/gen/f32-gemm-1x4-minmax-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-1x4-relu-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-1x4-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x2-minmax-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x2-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x4-minmax-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x4-relu-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x4-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-ibilinear-chw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-ibilinear-chw/gen/f32-ibilinear-chw-scalar-p4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-ibilinear-chw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-ibilinear-chw/gen/f32-ibilinear-chw-scalar-p4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-ibilinear_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-ibilinear/gen/f32-ibilinear-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-ibilinear_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-ibilinear/gen/f32-ibilinear-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-igemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-igemm/gen/f32-igemm-1x4-minmax-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-1x4-relu-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-1x4-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x2-minmax-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x2-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x4-minmax-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x4-relu-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x4-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-igemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-igemm/gen/f32-igemm-1x4-minmax-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-1x4-relu-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-1x4-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x2-minmax-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x2-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x4-minmax-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x4-relu-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x4-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-maxpool_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-maxpool/gen/f32-maxpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-maxpool_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-maxpool/gen/f32-maxpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-qc4w-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qc4w-gemm/gen/f32-qc4w-gemm-1x4-minmax-scalar.c",
++        "src/src/f32-qc4w-gemm/gen/f32-qc4w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-qc4w-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qc4w-gemm/gen/f32-qc4w-gemm-1x4-minmax-scalar.c",
++        "src/src/f32-qc4w-gemm/gen/f32-qc4w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-qc8w-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qc8w-gemm/gen/f32-qc8w-gemm-1x4-minmax-scalar.c",
++        "src/src/f32-qc8w-gemm/gen/f32-qc8w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-qc8w-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qc8w-gemm/gen/f32-qc8w-gemm-1x4-minmax-scalar.c",
++        "src/src/f32-qc8w-gemm/gen/f32-qc8w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-qs8-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qs8-vcvt/gen/f32-qs8-vcvt-scalar-imagic-u4.c",
++        "src/src/f32-qs8-vcvt/gen/f32-qs8-vcvt-scalar-lrintf-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-qs8-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qs8-vcvt/gen/f32-qs8-vcvt-scalar-imagic-u4.c",
++        "src/src/f32-qs8-vcvt/gen/f32-qs8-vcvt-scalar-lrintf-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-qu8-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qu8-vcvt/gen/f32-qu8-vcvt-scalar-imagic-u4.c",
++        "src/src/f32-qu8-vcvt/gen/f32-qu8-vcvt-scalar-lrintf-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-qu8-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qu8-vcvt/gen/f32-qu8-vcvt-scalar-imagic-u4.c",
++        "src/src/f32-qu8-vcvt/gen/f32-qu8-vcvt-scalar-lrintf-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-raddstoreexpminusmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-raddstoreexpminusmax/gen/f32-raddstoreexpminusmax-scalar-rr2-p5-u4-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-raddstoreexpminusmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-raddstoreexpminusmax/gen/f32-raddstoreexpminusmax-scalar-rr2-p5-u4-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-rdminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rdminmax/gen/f32-rdmax-2p2x-scalar-u2.c",
++        "src/src/f32-rdminmax/gen/f32-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-rdminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rdminmax/gen/f32-rdmax-2p2x-scalar-u2.c",
++        "src/src/f32-rdminmax/gen/f32-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-rdsum2_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rdsum2/gen/f32-rdsum2-7p7x-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-rdsum2_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rdsum2/gen/f32-rdsum2-7p7x-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-rdsum_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rdsum/gen/f32-rdsum-7p7x-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-rdsum_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rdsum/gen/f32-rdsum-7p7x-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-rminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rminmax/gen/f32-rmax-scalar-u4-acc4.c",
++        "src/src/f32-rminmax/gen/f32-rmin-scalar-u4-acc4.c",
++        "src/src/f32-rminmax/gen/f32-rminmax-scalar-u4-acc4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-rminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rminmax/gen/f32-rmax-scalar-u4-acc4.c",
++        "src/src/f32-rminmax/gen/f32-rmin-scalar-u4-acc4.c",
++        "src/src/f32-rminmax/gen/f32-rminmax-scalar-u4-acc4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-rsum2_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rsum2/gen/f32-rsum2-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-rsum2_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rsum2/gen/f32-rsum2-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-rsum_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rsum/gen/f32-rsum-scalar-u4-acc4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-rsum_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rsum/gen/f32-rsum-scalar-u4-acc4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-spmm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-spmm/gen/f32-spmm-8x1-minmax-scalar.c",
++        "src/src/f32-spmm/gen/f32-spmm-8x2-minmax-scalar.c",
++        "src/src/f32-spmm/gen/f32-spmm-8x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-spmm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-spmm/gen/f32-spmm-8x1-minmax-scalar.c",
++        "src/src/f32-spmm/gen/f32-spmm-8x2-minmax-scalar.c",
++        "src/src/f32-spmm/gen/f32-spmm-8x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vapproxgelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vapproxgelu/gen/f32-vapproxgelu-scalar-rational-12-10-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vapproxgelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vapproxgelu/gen/f32-vapproxgelu-scalar-rational-12-10-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vbinary_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vbinary/gen/f32-vadd-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vaddc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vdiv-scalar-u2.c",
++        "src/src/f32-vbinary/gen/f32-vdivc-scalar-u2.c",
++        "src/src/f32-vbinary/gen/f32-vmax-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmaxc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmin-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vminc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmul-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmulc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vprelu-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vpreluc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vrdivc-scalar-u2.c",
++        "src/src/f32-vbinary/gen/f32-vrpreluc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vrsubc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsqrdiff-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsqrdiffc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsub-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsubc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vbinary_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vbinary/gen/f32-vadd-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vaddc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vdiv-scalar-u2.c",
++        "src/src/f32-vbinary/gen/f32-vdivc-scalar-u2.c",
++        "src/src/f32-vbinary/gen/f32-vmax-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmaxc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmin-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vminc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmul-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmulc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vprelu-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vpreluc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vrdivc-scalar-u2.c",
++        "src/src/f32-vbinary/gen/f32-vrpreluc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vrsubc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsqrdiff-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsqrdiffc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsub-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsubc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vclamp_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vclamp/gen/f32-vclamp-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vclamp_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vclamp/gen/f32-vclamp-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vcmul_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vcmul/gen/f32-vcmul-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vcmul_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vcmul/gen/f32-vcmul-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vcopysign_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vcopysign/gen/f32-vcopysign-scalar.c",
++        "src/src/f32-vcopysign/gen/f32-vcopysignc-scalar.c",
++        "src/src/f32-vcopysign/gen/f32-vrcopysignc-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vcopysign_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vcopysign/gen/f32-vcopysign-scalar.c",
++        "src/src/f32-vcopysign/gen/f32-vcopysignc-scalar.c",
++        "src/src/f32-vcopysign/gen/f32-vrcopysignc-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vcos_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vcos/gen/f32-vcos-scalar-rational-5-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vcos_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vcos/gen/f32-vcos-scalar-rational-5-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-velu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-velu/gen/f32-velu-scalar-rr2-lut16-p3-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-velu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-velu/gen/f32-velu-scalar-rr2-lut16-p3-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vexp_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vexp/gen/f32-vexp-scalar-rational-3-2-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vexp_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vexp/gen/f32-vexp-scalar-rational-3-2-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vgelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vgelu/gen/f32-vgelu-scalar-rational-12-10-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vgelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vgelu/gen/f32-vgelu-scalar-rational-12-10-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vhswish_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vhswish/gen/f32-vhswish-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vhswish_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vhswish/gen/f32-vhswish-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vlog_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vlog/gen/f32-vlog-scalar-rational-3-3-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vlog_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vlog/gen/f32-vlog-scalar-rational-3-3-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vlrelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vlrelu/gen/f32-vlrelu-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vlrelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vlrelu/gen/f32-vlrelu-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vmulcaddc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vmulcaddc/gen/f32-vmulcaddc-c1-minmax-scalar-2x.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vmulcaddc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vmulcaddc/gen/f32-vmulcaddc-c1-minmax-scalar-2x.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vrnd_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vrnd/gen/f32-vrndd-scalar-libm-u1.c",
++        "src/src/f32-vrnd/gen/f32-vrndne-scalar-libm-u1.c",
++        "src/src/f32-vrnd/gen/f32-vrndu-scalar-libm-u1.c",
++        "src/src/f32-vrnd/gen/f32-vrndz-scalar-libm-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vrnd_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vrnd/gen/f32-vrndd-scalar-libm-u1.c",
++        "src/src/f32-vrnd/gen/f32-vrndne-scalar-libm-u1.c",
++        "src/src/f32-vrnd/gen/f32-vrndu-scalar-libm-u1.c",
++        "src/src/f32-vrnd/gen/f32-vrndz-scalar-libm-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vrsqrt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vrsqrt/gen/f32-vrsqrt-scalar-rsqrt-u1.c",
++        "src/src/f32-vrsqrt/gen/f32-vrsqrt-scalar-sqrt.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vrsqrt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vrsqrt/gen/f32-vrsqrt-scalar-rsqrt-u1.c",
++        "src/src/f32-vrsqrt/gen/f32-vrsqrt-scalar-sqrt.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vsigmoid_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vsigmoid/gen/f32-vsigmoid-scalar-rr2-lut64-p2-div-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vsigmoid_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vsigmoid/gen/f32-vsigmoid-scalar-rr2-lut64-p2-div-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vsin_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vsin/gen/f32-vsin-scalar-rational-5-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vsin_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vsin/gen/f32-vsin-scalar-rational-5-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vsqrt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vsqrt/gen/f32-vsqrt-scalar-sqrt.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vsqrt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vsqrt/gen/f32-vsqrt-scalar-sqrt.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vtanh_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vtanh/gen/f32-vtanh-scalar-rational-9-8-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vtanh_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vtanh/gen/f32-vtanh-scalar-rational-9-8-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vunary_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vunary/gen/f32-vabs-scalar.c",
++        "src/src/f32-vunary/gen/f32-vneg-scalar.c",
++        "src/src/f32-vunary/gen/f32-vsqr-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vunary_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vunary/gen/f32-vabs-scalar.c",
++        "src/src/f32-vunary/gen/f32-vneg-scalar.c",
++        "src/src/f32-vunary/gen/f32-vsqr-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
 +    source_set("operators_loong64") {
 +      cflags = []
 +
@@ -177,35 +3536,6 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/th
 +        "src/src/operators/transpose-nd.c",
 +        "src/src/operators/unary-elementwise-nc.c",
 +        "src/src/operators/unpooling-nhwc.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("enums_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/enums/allocation-type.c",
-+        "src/src/enums/datatype-strings.c",
-+        "src/src/enums/microkernel-type.c",
-+        "src/src/enums/node-type.c",
-+        "src/src/enums/operator-type.c",
 +      ]
 +
 +      configs -= [ "//build/config/compiler:chromium_code" ]
@@ -274,24 +3604,3881 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/th
 +    }
 +  }
 +
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("enums_loong64_standalone") {
++  if (build_with_chromium) {
++    source_set("qd8-f32-qb4w-gemm_loong64") {
 +      cflags = []
 +
 +      sources = [
 +        "src/include/xnnpack.h",
-+        "src/src/enums/allocation-type.c",
-+        "src/src/enums/datatype-strings.c",
-+        "src/src/enums/microkernel-type.c",
-+        "src/src/enums/node-type.c",
-+        "src/src/enums/operator-type.c",
++        "src/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4-minmax-scalar.c",
 +      ]
 +
 +      configs -= [ "//build/config/compiler:chromium_code" ]
-       configs += [ "//build/config/compiler:no_chromium_code" ]
-       configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-       configs += [ ":xnnpack_private_config" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qd8-f32-qb4w-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qd8-f32-qc4w-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qd8-f32-qc4w-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qd8-f32-qc8w-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-1x2-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qd8-f32-qc8w-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-1x2-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qd8-f32-qc8w-igemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-1x2-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qd8-f32-qc8w-igemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-1x2-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-dwconv_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-dwconv_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-f32-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-f32-vcvt/gen/qs8-f32-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-f32-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-f32-vcvt/gen/qs8-f32-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-packw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-packw/gen/qs8-packw-x16c8-gemm-goi-scalar.c",
++        "src/src/qs8-packw/gen/qs8-packw-x4c8-gemm-gio-scalar.c",
++        "src/src/qs8-packw/gen/qs8-packw-x4c8-gemm-goi-scalar.c",
++        "src/src/qs8-packw/gen/qs8-packw-x8c8-gemm-gio-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-packw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-packw/gen/qs8-packw-x16c8-gemm-goi-scalar.c",
++        "src/src/qs8-packw/gen/qs8-packw-x4c8-gemm-gio-scalar.c",
++        "src/src/qs8-packw/gen/qs8-packw-x4c8-gemm-goi-scalar.c",
++        "src/src/qs8-packw/gen/qs8-packw-x8c8-gemm-gio-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-qc4w-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc4w-gemm/gen/qs8-qc4w-gemm-1x4-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc4w-gemm/gen/qs8-qc4w-gemm-3x4-minmax-fp32-scalar-fmagic.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-qc4w-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc4w-gemm/gen/qs8-qc4w-gemm-1x4-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc4w-gemm/gen/qs8-qc4w-gemm-3x4-minmax-fp32-scalar-fmagic.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-qc8w-dwconv_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-qc8w-dwconv_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-qc8w-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc8w-gemm/gen/qs8-qc8w-gemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-gemm/gen/qs8-qc8w-gemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-qc8w-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc8w-gemm/gen/qs8-qc8w-gemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-gemm/gen/qs8-qc8w-gemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-qc8w-igemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc8w-igemm/gen/qs8-qc8w-igemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-igemm/gen/qs8-qc8w-igemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-qc8w-igemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc8w-igemm/gen/qs8-qc8w-igemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-igemm/gen/qs8-qc8w-igemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-qu8-packw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qu8-packw/gen/qs8-qu8-packw-x16c8-gemm-goi-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-qu8-packw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qu8-packw/gen/qs8-qu8-packw-x16c8-gemm-goi-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-rdsum_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-rdsum/gen/qs8-rdsum-minmax-fp32-scalar-u1-acc1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-rdsum_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-rdsum/gen/qs8-rdsum-minmax-fp32-scalar-u1-acc1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-rsum_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-rsum/gen/qs8-rsum-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-rsum_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-rsum/gen/qs8-rsum-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vadd_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vadd/gen/qs8-vadd-minmax-scalar-u1.c",
++        "src/src/qs8-vadd/gen/qs8-vadd-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vadd_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vadd/gen/qs8-vadd-minmax-scalar-u1.c",
++        "src/src/qs8-vadd/gen/qs8-vadd-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vaddc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vaddc/gen/qs8-vaddc-minmax-scalar-u1.c",
++        "src/src/qs8-vaddc/gen/qs8-vaddc-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vaddc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vaddc/gen/qs8-vaddc-minmax-scalar-u1.c",
++        "src/src/qs8-vaddc/gen/qs8-vaddc-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vcvt/gen/qs8-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vcvt/gen/qs8-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vlrelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vlrelu/gen/qs8-vlrelu-scalar-andxor-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vlrelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vlrelu/gen/qs8-vlrelu-scalar-andxor-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vmul_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vmul/gen/qs8-vmul-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vmul_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vmul/gen/qs8-vmul-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vmulc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vmulc/gen/qs8-vmulc-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vmulc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vmulc/gen/qs8-vmulc-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vprelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vprelu/gen/qs8-vprelu-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vprelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vprelu/gen/qs8-vprelu-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vpreluc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vpreluc/gen/qs8-vpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vpreluc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vpreluc/gen/qs8-vpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vrpreluc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vrpreluc/gen/qs8-vrpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vrpreluc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vrpreluc/gen/qs8-vrpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-dwconv_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-dwconv_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-f32-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-f32-vcvt/gen/qu8-f32-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-f32-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-f32-vcvt/gen/qu8-f32-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-gemm/gen/qu8-gemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qu8-gemm/gen/qu8-gemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-gemm/gen/qu8-gemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qu8-gemm/gen/qu8-gemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-igemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-igemm/gen/qu8-igemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qu8-igemm/gen/qu8-igemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-igemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-igemm/gen/qu8-igemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qu8-igemm/gen/qu8-igemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-rdsum_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-rdsum/gen/qu8-rdsum-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-rdsum_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-rdsum/gen/qu8-rdsum-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-rsum_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-rsum/gen/qu8-rsum-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-rsum_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-rsum/gen/qu8-rsum-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vadd_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vadd/gen/qu8-vadd-minmax-scalar-u1.c",
++        "src/src/qu8-vadd/gen/qu8-vadd-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vadd_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vadd/gen/qu8-vadd-minmax-scalar-u1.c",
++        "src/src/qu8-vadd/gen/qu8-vadd-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vaddc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vaddc/gen/qu8-vaddc-minmax-scalar-u1.c",
++        "src/src/qu8-vaddc/gen/qu8-vaddc-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vaddc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vaddc/gen/qu8-vaddc-minmax-scalar-u1.c",
++        "src/src/qu8-vaddc/gen/qu8-vaddc-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vcvt/gen/qu8-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vcvt/gen/qu8-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vlrelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vlrelu/gen/qu8-vlrelu-scalar-andxor-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vlrelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vlrelu/gen/qu8-vlrelu-scalar-andxor-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vmul_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vmul/gen/qu8-vmul-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vmul_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vmul/gen/qu8-vmul-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vmulc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vmulc/gen/qu8-vmulc-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vmulc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vmulc/gen/qu8-vmulc-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vprelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vprelu/gen/qu8-vprelu-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vprelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vprelu/gen/qu8-vprelu-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vpreluc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vpreluc/gen/qu8-vpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vpreluc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vpreluc/gen/qu8-vpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vrpreluc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vrpreluc/gen/qu8-vrpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vrpreluc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vrpreluc/gen/qu8-vrpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("reference_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/reference/binary-elementwise.cc",
++        "src/src/reference/packing.cc",
++        "src/src/reference/unary-elementwise.cc",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("reference_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/reference/binary-elementwise.cc",
++        "src/src/reference/packing.cc",
++        "src/src/reference/unary-elementwise.cc",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("s8-ibilinear_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-ibilinear/gen/s8-ibilinear-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("s8-ibilinear_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-ibilinear/gen/s8-ibilinear-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("s8-maxpool_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-maxpool/gen/s8-maxpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("s8-maxpool_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-maxpool/gen/s8-maxpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("s8-rdminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-rdminmax/gen/s8-rdmax-2p2x-scalar-u2.c",
++        "src/src/s8-rdminmax/gen/s8-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("s8-rdminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-rdminmax/gen/s8-rdmax-2p2x-scalar-u2.c",
++        "src/src/s8-rdminmax/gen/s8-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("s8-rminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-rminmax/gen/s8-rmax-scalar-u2-acc2.c",
++        "src/src/s8-rminmax/gen/s8-rmin-scalar-u2-acc2.c",
++        "src/src/s8-rminmax/gen/s8-rminmax-scalar-u2-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("s8-rminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-rminmax/gen/s8-rmax-scalar-u2-acc2.c",
++        "src/src/s8-rminmax/gen/s8-rmin-scalar-u2-acc2.c",
++        "src/src/s8-rminmax/gen/s8-rminmax-scalar-u2-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("s8-vclamp_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-vclamp/s8-vclamp-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("s8-vclamp_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-vclamp/s8-vclamp-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("subgraph_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/subgraph/argmax-pooling-2d.c",
++        "src/src/subgraph/average-pooling-2d.c",
++        "src/src/subgraph/batch-matrix-multiply.c",
++        "src/src/subgraph/binary.c",
++        "src/src/subgraph/concatenate.c",
++        "src/src/subgraph/convolution-2d.c",
++        "src/src/subgraph/copy.c",
++        "src/src/subgraph/deconvolution-2d.c",
++        "src/src/subgraph/deprecated.c",
++        "src/src/subgraph/depth-to-space-2d.c",
++        "src/src/subgraph/depthwise-convolution-2d.c",
++        "src/src/subgraph/even-split.c",
++        "src/src/subgraph/fully-connected-sparse.c",
++        "src/src/subgraph/fully-connected.c",
++        "src/src/subgraph/max-pooling-2d.c",
++        "src/src/subgraph/pack-lh.c",
++        "src/src/subgraph/reshape-helpers.c",
++        "src/src/subgraph/rope.c",
++        "src/src/subgraph/softmax.c",
++        "src/src/subgraph/space-to-depth-2d.c",
++        "src/src/subgraph/static-constant-pad.c",
++        "src/src/subgraph/static-reduce.c",
++        "src/src/subgraph/static-resize-bilinear-2d.c",
++        "src/src/subgraph/static-slice.c",
++        "src/src/subgraph/static-transpose.c",
++        "src/src/subgraph/subgraph-utils.c",
++        "src/src/subgraph/unary.c",
++        "src/src/subgraph/unpooling-2d.c",
++        "src/src/subgraph/validation.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("subgraph_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/subgraph/argmax-pooling-2d.c",
++        "src/src/subgraph/average-pooling-2d.c",
++        "src/src/subgraph/batch-matrix-multiply.c",
++        "src/src/subgraph/binary.c",
++        "src/src/subgraph/concatenate.c",
++        "src/src/subgraph/convolution-2d.c",
++        "src/src/subgraph/copy.c",
++        "src/src/subgraph/deconvolution-2d.c",
++        "src/src/subgraph/deprecated.c",
++        "src/src/subgraph/depth-to-space-2d.c",
++        "src/src/subgraph/depthwise-convolution-2d.c",
++        "src/src/subgraph/even-split.c",
++        "src/src/subgraph/fully-connected-sparse.c",
++        "src/src/subgraph/fully-connected.c",
++        "src/src/subgraph/max-pooling-2d.c",
++        "src/src/subgraph/pack-lh.c",
++        "src/src/subgraph/reshape-helpers.c",
++        "src/src/subgraph/rope.c",
++        "src/src/subgraph/softmax.c",
++        "src/src/subgraph/space-to-depth-2d.c",
++        "src/src/subgraph/static-constant-pad.c",
++        "src/src/subgraph/static-reduce.c",
++        "src/src/subgraph/static-resize-bilinear-2d.c",
++        "src/src/subgraph/static-slice.c",
++        "src/src/subgraph/static-transpose.c",
++        "src/src/subgraph/subgraph-utils.c",
++        "src/src/subgraph/unary.c",
++        "src/src/subgraph/unpooling-2d.c",
++        "src/src/subgraph/validation.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("tables_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/tables/exp2-k-over-2048.c",
++        "src/src/tables/exp2-k-over-64.c",
++        "src/src/tables/exp2minus-k-over-16.c",
++        "src/src/tables/exp2minus-k-over-2048.c",
++        "src/src/tables/exp2minus-k-over-32.c",
++        "src/src/tables/exp2minus-k-over-4.c",
++        "src/src/tables/exp2minus-k-over-64.c",
++        "src/src/tables/exp2minus-k-over-8.c",
++        "src/src/tables/vlog.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("tables_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/tables/exp2-k-over-2048.c",
++        "src/src/tables/exp2-k-over-64.c",
++        "src/src/tables/exp2minus-k-over-16.c",
++        "src/src/tables/exp2minus-k-over-2048.c",
++        "src/src/tables/exp2minus-k-over-32.c",
++        "src/src/tables/exp2minus-k-over-4.c",
++        "src/src/tables/exp2minus-k-over-64.c",
++        "src/src/tables/exp2minus-k-over-8.c",
++        "src/src/tables/vlog.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("u8-ibilinear_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-ibilinear/gen/u8-ibilinear-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("u8-ibilinear_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-ibilinear/gen/u8-ibilinear-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("u8-lut32norm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-lut32norm/u8-lut32norm-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("u8-lut32norm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-lut32norm/u8-lut32norm-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("u8-maxpool_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-maxpool/gen/u8-maxpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("u8-maxpool_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-maxpool/gen/u8-maxpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("u8-rdminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-rdminmax/gen/u8-rdmax-2p2x-scalar-u2.c",
++        "src/src/u8-rdminmax/gen/u8-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("u8-rdminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-rdminmax/gen/u8-rdmax-2p2x-scalar-u2.c",
++        "src/src/u8-rdminmax/gen/u8-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("u8-rminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-rminmax/gen/u8-rmax-scalar-u2-acc2.c",
++        "src/src/u8-rminmax/gen/u8-rmin-scalar-u2-acc2.c",
++        "src/src/u8-rminmax/gen/u8-rminmax-scalar-u2-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("u8-rminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-rminmax/gen/u8-rmax-scalar-u2-acc2.c",
++        "src/src/u8-rminmax/gen/u8-rmin-scalar-u2-acc2.c",
++        "src/src/u8-rminmax/gen/u8-rminmax-scalar-u2-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("u8-vclamp_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-vclamp/u8-vclamp-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("u8-vclamp_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-vclamp/u8-vclamp-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x16-transposec_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x16-transposec/gen/x16-transposec-2x4-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x16-transposec_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x16-transposec/gen/x16-transposec-2x4-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x16-x32-packw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x16-x32-packw/gen/x16-x32-packw-x32c2-gemm-gio-scalar.c",
++        "src/src/x16-x32-packw/gen/x16-x32-packw-x32c2-gemm-goi-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x16-x32-packw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x16-x32-packw/gen/x16-x32-packw-x32c2-gemm-gio-scalar.c",
++        "src/src/x16-x32-packw/gen/x16-x32-packw-x32c2-gemm-goi-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x24-transposec_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x24-transposec/gen/x24-transposec-1x2-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x24-transposec_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x24-transposec/gen/x24-transposec-1x2-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x32-packw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x32-packw/gen/x32-packw-x2-gemm-gio-scalar.c",
++        "src/src/x32-packw/gen/x32-packw-x2-gemm-goi-scalar-float-u4.c",
++        "src/src/x32-packw/gen/x32-packw-x32-gemm-goi-scalar-int-u2.c",
++        "src/src/x32-packw/gen/x32-packw-x4-gemm-gio-scalar.c",
++        "src/src/x32-packw/gen/x32-packw-x4-gemm-goi-scalar-float-u4.c",
++        "src/src/x32-packw/gen/x32-packw-x64-gemm-goi-scalar-int-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x32-packw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x32-packw/gen/x32-packw-x2-gemm-gio-scalar.c",
++        "src/src/x32-packw/gen/x32-packw-x2-gemm-goi-scalar-float-u4.c",
++        "src/src/x32-packw/gen/x32-packw-x32-gemm-goi-scalar-int-u2.c",
++        "src/src/x32-packw/gen/x32-packw-x4-gemm-gio-scalar.c",
++        "src/src/x32-packw/gen/x32-packw-x4-gemm-goi-scalar-float-u4.c",
++        "src/src/x32-packw/gen/x32-packw-x64-gemm-goi-scalar-int-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x32-transposec_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x32-transposec/gen/x32-transposec-2x4-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x32-transposec_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x32-transposec/gen/x32-transposec-2x4-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x32-unpool_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x32-unpool/x32-unpool-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x32-unpool_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x32-unpool/x32-unpool-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x64-transposec_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x64-transposec/gen/x64-transposec-4x2-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x64-transposec_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x64-transposec/gen/x64-transposec-4x2-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x8-lut_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-lut/gen/x8-lut-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x8-lut_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-lut/gen/x8-lut-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x8-packq_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-packq/x8-packq-scalar-f32qp8-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x8-packq_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-packq/x8-packq-scalar-f32qp8-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x8-packw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-packw/gen/x8-packw-x16-gemm-goi-scalar-u2.c",
++        "src/src/x8-packw/gen/x8-packw-x32-gemm-goi-scalar-u2.c",
++        "src/src/x8-packw/gen/x8-packw-x4-gemm-goi-scalar-u2.c",
++        "src/src/x8-packw/gen/x8-packw-x8-gemm-goi-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x8-packw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-packw/gen/x8-packw-x16-gemm-goi-scalar-u2.c",
++        "src/src/x8-packw/gen/x8-packw-x32-gemm-goi-scalar-u2.c",
++        "src/src/x8-packw/gen/x8-packw-x4-gemm-goi-scalar-u2.c",
++        "src/src/x8-packw/gen/x8-packw-x8-gemm-goi-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x8-transposec_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-transposec/gen/x8-transposec-2x4-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x8-transposec_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-transposec/gen/x8-transposec-2x4-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("xx-copy_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-copy/xx-copy-scalar-memcpy.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("xx-copy_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-copy/xx-copy-scalar-memcpy.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("xx-fill_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-fill/xx-fill-scalar-u16.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("xx-fill_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-fill/xx-fill-scalar-u16.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("xx-pad_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-pad/xx-pad-p4-scalar-u16.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("xx-pad_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-pad/xx-pad-p4-scalar-u16.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("xx-transposev_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-transposev/xx-transposev-1x1-scalar-memcpy.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("xx-transposev_loong64_standalone") {
++      cflags = []
++
++      sources = [
+         "src/include/xnnpack.h",
+         "src/src/xx-transposev/xx-transposev-1x1-scalar-memcpy.c",
+       ]
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/xnnpack/bazelroot/BUILD b/third_party/xnnpack/bazelroot/BUILD
+--- a/third_party/xnnpack/bazelroot/BUILD	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/xnnpack/bazelroot/BUILD	2000-01-01 00:00:00.000000000 +0800
+@@ -29,6 +29,19 @@ platform(
+     ],
+ )
+ 
++constraint_value(
++    name = "loongarch64",
++    constraint_setting = "@platforms//cpu:cpu",
++)
++
++platform(
++    name = "linux_loongarch64",
++    constraint_values = [
++        "@platforms//os:linux",
++        ":loongarch64",
++    ],
++)
++
+ # A dummy clang toolchain for building them for any arch.
+ 
+ filegroup(name = "empty")
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/xnnpack/generate_build_gn.py b/third_party/xnnpack/generate_build_gn.py
+--- a/third_party/xnnpack/generate_build_gn.py	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/xnnpack/generate_build_gn.py	2000-01-01 00:00:00.000000000 +0800
+@@ -239,7 +239,10 @@ _PLATFORMS = [
+               bazel_platform='//:linux_aarch64'),
+     _Platform(gn_cpu='riscv64',
+               bazel_cpu='riscv64',
+-              bazel_platform='//:linux_riscv64')
++              bazel_platform='//:linux_riscv64'),
++_Platform(gn_cpu='loong64',
++              bazel_cpu='loongarch64',
++              bazel_platform='//:linux_loongarch64')
+ ]
+ 
+ 
+@@ -352,7 +355,7 @@ def _run_bazel_cmd(args: list[str]) -> s
+       Exception if the command failed.
+     """
+     # Use standard Bazel install instead of the one included with depot_tools.
+-    exec_path = "/usr/bin/bazel"
++    exec_path = os.getenv("BAZEL_PATH_OVERRIDE") or "/usr/bin/bazel"
+     if not exec_path:
+         raise Exception(
+             "bazel is not installed. Please run `sudo apt-get install " +
 diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/xnnpack/src/src/xnnpack/common.h b/third_party/xnnpack/src/src/xnnpack/common.h
 --- a/third_party/xnnpack/src/src/xnnpack/common.h	2000-01-01 00:00:00.000000000 +0800
 +++ b/third_party/xnnpack/src/src/xnnpack/common.h	2000-01-01 00:00:00.000000000 +0800

--- a/chromium/chromium-142.0.7444.134.diff
+++ b/chromium/chromium-142.0.7444.134.diff
@@ -16346,8 +16346,8 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/th
 diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/xnnpack/BUILD.gn b/third_party/xnnpack/BUILD.gn
 --- a/third_party/xnnpack/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
 +++ b/third_party/xnnpack/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
-@@ -1534,6 +1534,22 @@ if (current_cpu == "x64" || current_cpu
-       ":xx-transposev_arm64_standalone",
+@@ -1884,6 +1884,262 @@ if (current_cpu == "x64" || current_cpu
+       ":xx-transposev_riscv64_standalone",
      ]
    }
 +} else if (current_cpu == "loong64") {
@@ -16355,7 +16355,127 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/th
 +    xnnpack_deps = [
 +      ":configs_loong64",
 +      ":enums_loong64",
++      ":f16-f32-vcvt_loong64",
++      ":f16-qs8-vcvt_loong64",
++      ":f16-qu8-vcvt_loong64",
++      ":f16-rdminmax_loong64",
++      ":f16-rminmax_loong64",
++      ":f16-vapproxgelu_loong64",
++      ":f16-vcos_loong64",
++      ":f16-vexp_loong64",
++      ":f16-vgelu_loong64",
++      ":f16-vsin_loong64",
++      ":f32-argmaxpool_loong64",
++      ":f32-avgpool_loong64",
++      ":f32-conv-hwc2chw_loong64",
++      ":f32-dwconv2d-chw_loong64",
++      ":f32-dwconv_loong64",
++      ":f32-f16-vcvt_loong64",
++      ":f32-gemm_loong64",
++      ":f32-ibilinear-chw_loong64",
++      ":f32-ibilinear_loong64",
++      ":f32-igemm_loong64",
++      ":f32-maxpool_loong64",
++      ":f32-qc4w-gemm_loong64",
++      ":f32-qc8w-gemm_loong64",
++      ":f32-qs8-vcvt_loong64",
++      ":f32-qu8-vcvt_loong64",
++      ":f32-raddstoreexpminusmax_loong64",
++      ":f32-rdminmax_loong64",
++      ":f32-rdsum2_loong64",
++      ":f32-rdsum_loong64",
++      ":f32-rminmax_loong64",
++      ":f32-rsum2_loong64",
++      ":f32-rsum_loong64",
++      ":f32-spmm_loong64",
++      ":f32-vapproxgelu_loong64",
++      ":f32-vbinary_loong64",
++      ":f32-vclamp_loong64",
++      ":f32-vcmul_loong64",
++      ":f32-vcopysign_loong64",
++      ":f32-vcos_loong64",
++      ":f32-velu_loong64",
++      ":f32-vexp_loong64",
++      ":f32-vgelu_loong64",
++      ":f32-vhswish_loong64",
++      ":f32-vlog_loong64",
++      ":f32-vlrelu_loong64",
++      ":f32-vmulcaddc_loong64",
++      ":f32-vrnd_loong64",
++      ":f32-vrsqrt_loong64",
++      ":f32-vsigmoid_loong64",
++      ":f32-vsin_loong64",
++      ":f32-vsqrt_loong64",
++      ":f32-vtanh_loong64",
++      ":f32-vunary_loong64",
 +      ":operators_loong64",
++      ":qd8-f32-qb4w-gemm_loong64",
++      ":qd8-f32-qc4w-gemm_loong64",
++      ":qd8-f32-qc8w-gemm_loong64",
++      ":qd8-f32-qc8w-igemm_loong64",
++      ":qs8-dwconv_loong64",
++      ":qs8-f32-vcvt_loong64",
++      ":qs8-packw_loong64",
++      ":qs8-qc4w-gemm_loong64",
++      ":qs8-qc8w-dwconv_loong64",
++      ":qs8-qc8w-gemm_loong64",
++      ":qs8-qc8w-igemm_loong64",
++      ":qs8-qu8-packw_loong64",
++      ":qs8-rdsum_loong64",
++      ":qs8-rsum_loong64",
++      ":qs8-vadd_loong64",
++      ":qs8-vaddc_loong64",
++      ":qs8-vcvt_loong64",
++      ":qs8-vlrelu_loong64",
++      ":qs8-vmul_loong64",
++      ":qs8-vmulc_loong64",
++      ":qs8-vprelu_loong64",
++      ":qs8-vpreluc_loong64",
++      ":qs8-vrpreluc_loong64",
++      ":qu8-dwconv_loong64",
++      ":qu8-f32-vcvt_loong64",
++      ":qu8-gemm_loong64",
++      ":qu8-igemm_loong64",
++      ":qu8-rdsum_loong64",
++      ":qu8-rsum_loong64",
++      ":qu8-vadd_loong64",
++      ":qu8-vaddc_loong64",
++      ":qu8-vcvt_loong64",
++      ":qu8-vlrelu_loong64",
++      ":qu8-vmul_loong64",
++      ":qu8-vmulc_loong64",
++      ":qu8-vprelu_loong64",
++      ":qu8-vpreluc_loong64",
++      ":qu8-vrpreluc_loong64",
++      ":reference_loong64",
++      ":s8-ibilinear_loong64",
++      ":s8-maxpool_loong64",
++      ":s8-rdminmax_loong64",
++      ":s8-rminmax_loong64",
++      ":s8-vclamp_loong64",
++      ":subgraph_loong64",
++      ":tables_loong64",
++      ":u8-ibilinear_loong64",
++      ":u8-lut32norm_loong64",
++      ":u8-maxpool_loong64",
++      ":u8-rdminmax_loong64",
++      ":u8-rminmax_loong64",
++      ":u8-vclamp_loong64",
++      ":x16-transposec_loong64",
++      ":x16-x32-packw_loong64",
++      ":x24-transposec_loong64",
++      ":x32-packw_loong64",
++      ":x32-transposec_loong64",
++      ":x32-unpool_loong64",
++      ":x64-transposec_loong64",
++      ":x8-lut_loong64",
++      ":x8-packq_loong64",
++      ":x8-packw_loong64",
++      ":x8-transposec_loong64",
++      ":xx-copy_loong64",
++      ":xx-fill_loong64",
++      ":xx-pad_loong64",
++      ":xx-transposev_loong64",
 +    ]
 +  }
 +
@@ -16363,16 +16483,141 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/th
 +    xnnpack_standalone_deps = [
 +      ":configs_loong64_standalone",
 +      ":enums_loong64_standalone",
++      ":f16-f32-vcvt_loong64_standalone",
++      ":f16-qs8-vcvt_loong64_standalone",
++      ":f16-qu8-vcvt_loong64_standalone",
++      ":f16-rdminmax_loong64_standalone",
++      ":f16-rminmax_loong64_standalone",
++      ":f16-vapproxgelu_loong64_standalone",
++      ":f16-vcos_loong64_standalone",
++      ":f16-vexp_loong64_standalone",
++      ":f16-vgelu_loong64_standalone",
++      ":f16-vsin_loong64_standalone",
++      ":f32-argmaxpool_loong64_standalone",
++      ":f32-avgpool_loong64_standalone",
++      ":f32-conv-hwc2chw_loong64_standalone",
++      ":f32-dwconv2d-chw_loong64_standalone",
++      ":f32-dwconv_loong64_standalone",
++      ":f32-f16-vcvt_loong64_standalone",
++      ":f32-gemm_loong64_standalone",
++      ":f32-ibilinear-chw_loong64_standalone",
++      ":f32-ibilinear_loong64_standalone",
++      ":f32-igemm_loong64_standalone",
++      ":f32-maxpool_loong64_standalone",
++      ":f32-qc4w-gemm_loong64_standalone",
++      ":f32-qc8w-gemm_loong64_standalone",
++      ":f32-qs8-vcvt_loong64_standalone",
++      ":f32-qu8-vcvt_loong64_standalone",
++      ":f32-raddstoreexpminusmax_loong64_standalone",
++      ":f32-rdminmax_loong64_standalone",
++      ":f32-rdsum2_loong64_standalone",
++      ":f32-rdsum_loong64_standalone",
++      ":f32-rminmax_loong64_standalone",
++      ":f32-rsum2_loong64_standalone",
++      ":f32-rsum_loong64_standalone",
++      ":f32-spmm_loong64_standalone",
++      ":f32-vapproxgelu_loong64_standalone",
++      ":f32-vbinary_loong64_standalone",
++      ":f32-vclamp_loong64_standalone",
++      ":f32-vcmul_loong64_standalone",
++      ":f32-vcopysign_loong64_standalone",
++      ":f32-vcos_loong64_standalone",
++      ":f32-velu_loong64_standalone",
++      ":f32-vexp_loong64_standalone",
++      ":f32-vgelu_loong64_standalone",
++      ":f32-vhswish_loong64_standalone",
++      ":f32-vlog_loong64_standalone",
++      ":f32-vlrelu_loong64_standalone",
++      ":f32-vmulcaddc_loong64_standalone",
++      ":f32-vrnd_loong64_standalone",
++      ":f32-vrsqrt_loong64_standalone",
++      ":f32-vsigmoid_loong64_standalone",
++      ":f32-vsin_loong64_standalone",
++      ":f32-vsqrt_loong64_standalone",
++      ":f32-vtanh_loong64_standalone",
++      ":f32-vunary_loong64_standalone",
 +      ":operators_loong64_standalone",
++      ":qd8-f32-qb4w-gemm_loong64_standalone",
++      ":qd8-f32-qc4w-gemm_loong64_standalone",
++      ":qd8-f32-qc8w-gemm_loong64_standalone",
++      ":qd8-f32-qc8w-igemm_loong64_standalone",
++      ":qs8-dwconv_loong64_standalone",
++      ":qs8-f32-vcvt_loong64_standalone",
++      ":qs8-packw_loong64_standalone",
++      ":qs8-qc4w-gemm_loong64_standalone",
++      ":qs8-qc8w-dwconv_loong64_standalone",
++      ":qs8-qc8w-gemm_loong64_standalone",
++      ":qs8-qc8w-igemm_loong64_standalone",
++      ":qs8-qu8-packw_loong64_standalone",
++      ":qs8-rdsum_loong64_standalone",
++      ":qs8-rsum_loong64_standalone",
++      ":qs8-vadd_loong64_standalone",
++      ":qs8-vaddc_loong64_standalone",
++      ":qs8-vcvt_loong64_standalone",
++      ":qs8-vlrelu_loong64_standalone",
++      ":qs8-vmul_loong64_standalone",
++      ":qs8-vmulc_loong64_standalone",
++      ":qs8-vprelu_loong64_standalone",
++      ":qs8-vpreluc_loong64_standalone",
++      ":qs8-vrpreluc_loong64_standalone",
++      ":qu8-dwconv_loong64_standalone",
++      ":qu8-f32-vcvt_loong64_standalone",
++      ":qu8-gemm_loong64_standalone",
++      ":qu8-igemm_loong64_standalone",
++      ":qu8-rdsum_loong64_standalone",
++      ":qu8-rsum_loong64_standalone",
++      ":qu8-vadd_loong64_standalone",
++      ":qu8-vaddc_loong64_standalone",
++      ":qu8-vcvt_loong64_standalone",
++      ":qu8-vlrelu_loong64_standalone",
++      ":qu8-vmul_loong64_standalone",
++      ":qu8-vmulc_loong64_standalone",
++      ":qu8-vprelu_loong64_standalone",
++      ":qu8-vpreluc_loong64_standalone",
++      ":qu8-vrpreluc_loong64_standalone",
++      ":reference_loong64_standalone",
++      ":s8-ibilinear_loong64_standalone",
++      ":s8-maxpool_loong64_standalone",
++      ":s8-rdminmax_loong64_standalone",
++      ":s8-rminmax_loong64_standalone",
++      ":s8-vclamp_loong64_standalone",
++      ":subgraph_loong64_standalone",
++      ":tables_loong64_standalone",
++      ":u8-ibilinear_loong64_standalone",
++      ":u8-lut32norm_loong64_standalone",
++      ":u8-maxpool_loong64_standalone",
++      ":u8-rdminmax_loong64_standalone",
++      ":u8-rminmax_loong64_standalone",
++      ":u8-vclamp_loong64_standalone",
++      ":x16-transposec_loong64_standalone",
++      ":x16-x32-packw_loong64_standalone",
++      ":x24-transposec_loong64_standalone",
++      ":x32-packw_loong64_standalone",
++      ":x32-transposec_loong64_standalone",
++      ":x32-unpool_loong64_standalone",
++      ":x64-transposec_loong64_standalone",
++      ":x8-lut_loong64_standalone",
++      ":x8-packq_loong64_standalone",
++      ":x8-packw_loong64_standalone",
++      ":x8-transposec_loong64_standalone",
++      ":xx-copy_loong64_standalone",
++      ":xx-fill_loong64_standalone",
++      ":xx-pad_loong64_standalone",
++      ":xx-transposev_loong64_standalone",
 +    ]
 +  }
- } else if (current_cpu == "riscv64") {
-   if (build_with_chromium) {
-     xnnpack_deps = [
-@@ -48112,6 +48128,267 @@ if (current_cpu == "arm64") {
-       ]
+ } else {
+   xnnpack_deps = []
+   if (build_with_internal_optimization_guide) {
+@@ -58223,6 +58479,7167 @@ if (current_cpu == "riscv64") {
+       cflags = []
  
-       configs -= [ "//build/config/compiler:chromium_code" ]
+       sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-transposev/xx-transposev-1x1-scalar-memcpy.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
 +      configs += [ "//build/config/compiler:no_chromium_code" ]
 +      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
 +      configs += [ ":xnnpack_private_config" ]
@@ -16496,6 +16741,3120 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/th
 +  }
 +
 +  if (build_with_chromium) {
++    source_set("enums_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/enums/allocation-type.c",
++        "src/src/enums/datatype-strings.c",
++        "src/src/enums/microkernel-type.c",
++        "src/src/enums/node-type.c",
++        "src/src/enums/operator-type.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("enums_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/enums/allocation-type.c",
++        "src/src/enums/datatype-strings.c",
++        "src/src/enums/microkernel-type.c",
++        "src/src/enums/node-type.c",
++        "src/src/enums/operator-type.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-f32-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-f32-vcvt/gen/f16-f32-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-f32-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-f32-vcvt/gen/f16-f32-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-qs8-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-qs8-vcvt/gen/f16-qs8-vcvt-scalar-imagic-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-qs8-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-qs8-vcvt/gen/f16-qs8-vcvt-scalar-imagic-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-qu8-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-qu8-vcvt/gen/f16-qu8-vcvt-scalar-imagic-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-qu8-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-qu8-vcvt/gen/f16-qu8-vcvt-scalar-imagic-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-rdminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-rdminmax/gen/f16-rdmax-2p2x-scalar-u2.c",
++        "src/src/f16-rdminmax/gen/f16-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-rdminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-rdminmax/gen/f16-rdmax-2p2x-scalar-u2.c",
++        "src/src/f16-rdminmax/gen/f16-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-rminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-rminmax/gen/f16-rmax-scalar-u2-acc2.c",
++        "src/src/f16-rminmax/gen/f16-rmin-scalar-u2-acc2.c",
++        "src/src/f16-rminmax/gen/f16-rminmax-scalar-u2-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-rminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-rminmax/gen/f16-rmax-scalar-u2-acc2.c",
++        "src/src/f16-rminmax/gen/f16-rmin-scalar-u2-acc2.c",
++        "src/src/f16-rminmax/gen/f16-rminmax-scalar-u2-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-vapproxgelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vapproxgelu/gen/f16-vapproxgelu-scalar-rational-6-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-vapproxgelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vapproxgelu/gen/f16-vapproxgelu-scalar-rational-6-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-vcos_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vcos/gen/f16-vcos-scalar-rational-3-2-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-vcos_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vcos/gen/f16-vcos-scalar-rational-3-2-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-vexp_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vexp/gen/f16-vexp-scalar-poly-3.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-vexp_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vexp/gen/f16-vexp-scalar-poly-3.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-vgelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vgelu/gen/f16-vgelu-scalar-rational-6-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-vgelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vgelu/gen/f16-vgelu-scalar-rational-6-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f16-vsin_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vsin/gen/f16-vsin-scalar-rational-3-2-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f16-vsin_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f16-vsin/gen/f16-vsin-scalar-rational-3-2-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-argmaxpool_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-argmaxpool/f32-argmaxpool-9p8x-scalar-c1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-argmaxpool_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-argmaxpool/f32-argmaxpool-9p8x-scalar-c1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-avgpool_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-avgpool/gen/f32-avgpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-avgpool_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-avgpool/gen/f32-avgpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-conv-hwc2chw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-conv-hwc2chw/f32-conv-hwc2chw-3x3s2p1c3x4-scalar-1x1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-conv-hwc2chw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-conv-hwc2chw/f32-conv-hwc2chw-3x3s2p1c3x4-scalar-1x1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-dwconv2d-chw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3p1-minmax-scalar-2x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3p1-minmax-scalar-4x1.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3s2p1-minmax-scalar-1x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3s2p1-minmax-scalar-2x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5p2-minmax-scalar-1x1-acc5.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5p2-minmax-scalar-2x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5s2p2-minmax-scalar-1x1-acc5.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5s2p2-minmax-scalar-2x1-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-dwconv2d-chw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3p1-minmax-scalar-2x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3p1-minmax-scalar-4x1.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3s2p1-minmax-scalar-1x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3s2p1-minmax-scalar-2x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5p2-minmax-scalar-1x1-acc5.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5p2-minmax-scalar-2x1-acc2.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5s2p2-minmax-scalar-1x1-acc5.c",
++        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5s2p2-minmax-scalar-2x1-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-dwconv_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p1c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p2c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p2c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-3p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-3p1c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-4p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-4p1c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-9p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-9p1c-scalar-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-dwconv_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p1c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p2c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-25p2c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-3p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-3p1c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-4p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-4p1c-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-9p1c-minmax-scalar-acc2.c",
++        "src/src/f32-dwconv/gen/f32-dwconv-9p1c-scalar-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-f16-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-f16-vcvt/gen/f32-f16-vcvt-scalar-fabsf-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-f16-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-f16-vcvt/gen/f32-f16-vcvt-scalar-fabsf-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-gemm/gen/f32-gemm-1x4-minmax-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-1x4-relu-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-1x4-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x2-minmax-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x2-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x4-minmax-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x4-relu-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x4-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-gemm/gen/f32-gemm-1x4-minmax-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-1x4-relu-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-1x4-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x2-minmax-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x2-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x4-minmax-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x4-relu-scalar.c",
++        "src/src/f32-gemm/gen/f32-gemm-4x4-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-ibilinear-chw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-ibilinear-chw/gen/f32-ibilinear-chw-scalar-p4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-ibilinear-chw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-ibilinear-chw/gen/f32-ibilinear-chw-scalar-p4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-ibilinear_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-ibilinear/gen/f32-ibilinear-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-ibilinear_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-ibilinear/gen/f32-ibilinear-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-igemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-igemm/gen/f32-igemm-1x4-minmax-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-1x4-relu-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-1x4-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x2-minmax-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x2-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x4-minmax-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x4-relu-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x4-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-igemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-igemm/gen/f32-igemm-1x4-minmax-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-1x4-relu-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-1x4-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x2-minmax-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x2-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x4-minmax-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x4-relu-scalar.c",
++        "src/src/f32-igemm/gen/f32-igemm-4x4-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-maxpool_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-maxpool/gen/f32-maxpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-maxpool_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-maxpool/gen/f32-maxpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-qc4w-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qc4w-gemm/gen/f32-qc4w-gemm-1x4-minmax-scalar.c",
++        "src/src/f32-qc4w-gemm/gen/f32-qc4w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-qc4w-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qc4w-gemm/gen/f32-qc4w-gemm-1x4-minmax-scalar.c",
++        "src/src/f32-qc4w-gemm/gen/f32-qc4w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-qc8w-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qc8w-gemm/gen/f32-qc8w-gemm-1x4-minmax-scalar.c",
++        "src/src/f32-qc8w-gemm/gen/f32-qc8w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-qc8w-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qc8w-gemm/gen/f32-qc8w-gemm-1x4-minmax-scalar.c",
++        "src/src/f32-qc8w-gemm/gen/f32-qc8w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-qs8-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qs8-vcvt/gen/f32-qs8-vcvt-scalar-imagic-u4.c",
++        "src/src/f32-qs8-vcvt/gen/f32-qs8-vcvt-scalar-lrintf-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-qs8-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qs8-vcvt/gen/f32-qs8-vcvt-scalar-imagic-u4.c",
++        "src/src/f32-qs8-vcvt/gen/f32-qs8-vcvt-scalar-lrintf-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-qu8-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qu8-vcvt/gen/f32-qu8-vcvt-scalar-imagic-u4.c",
++        "src/src/f32-qu8-vcvt/gen/f32-qu8-vcvt-scalar-lrintf-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-qu8-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-qu8-vcvt/gen/f32-qu8-vcvt-scalar-imagic-u4.c",
++        "src/src/f32-qu8-vcvt/gen/f32-qu8-vcvt-scalar-lrintf-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-raddstoreexpminusmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-raddstoreexpminusmax/gen/f32-raddstoreexpminusmax-scalar-rr2-p5-u4-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-raddstoreexpminusmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-raddstoreexpminusmax/gen/f32-raddstoreexpminusmax-scalar-rr2-p5-u4-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-rdminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rdminmax/gen/f32-rdmax-2p2x-scalar-u2.c",
++        "src/src/f32-rdminmax/gen/f32-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-rdminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rdminmax/gen/f32-rdmax-2p2x-scalar-u2.c",
++        "src/src/f32-rdminmax/gen/f32-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-rdsum2_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rdsum2/gen/f32-rdsum2-7p7x-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-rdsum2_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rdsum2/gen/f32-rdsum2-7p7x-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-rdsum_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rdsum/gen/f32-rdsum-7p7x-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-rdsum_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rdsum/gen/f32-rdsum-7p7x-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-rminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rminmax/gen/f32-rmax-scalar-u4-acc4.c",
++        "src/src/f32-rminmax/gen/f32-rmin-scalar-u4-acc4.c",
++        "src/src/f32-rminmax/gen/f32-rminmax-scalar-u4-acc4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-rminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rminmax/gen/f32-rmax-scalar-u4-acc4.c",
++        "src/src/f32-rminmax/gen/f32-rmin-scalar-u4-acc4.c",
++        "src/src/f32-rminmax/gen/f32-rminmax-scalar-u4-acc4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-rsum2_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rsum2/gen/f32-rsum2-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-rsum2_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rsum2/gen/f32-rsum2-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-rsum_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rsum/gen/f32-rsum-scalar-u4-acc4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-rsum_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-rsum/gen/f32-rsum-scalar-u4-acc4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-spmm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-spmm/gen/f32-spmm-8x1-minmax-scalar.c",
++        "src/src/f32-spmm/gen/f32-spmm-8x2-minmax-scalar.c",
++        "src/src/f32-spmm/gen/f32-spmm-8x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-spmm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-spmm/gen/f32-spmm-8x1-minmax-scalar.c",
++        "src/src/f32-spmm/gen/f32-spmm-8x2-minmax-scalar.c",
++        "src/src/f32-spmm/gen/f32-spmm-8x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vapproxgelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vapproxgelu/gen/f32-vapproxgelu-scalar-rational-12-10-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vapproxgelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vapproxgelu/gen/f32-vapproxgelu-scalar-rational-12-10-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vbinary_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vbinary/gen/f32-vadd-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vaddc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vdiv-scalar-u2.c",
++        "src/src/f32-vbinary/gen/f32-vdivc-scalar-u2.c",
++        "src/src/f32-vbinary/gen/f32-vmax-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmaxc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmin-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vminc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmul-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmulc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vprelu-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vpreluc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vrdivc-scalar-u2.c",
++        "src/src/f32-vbinary/gen/f32-vrpreluc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vrsubc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsqrdiff-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsqrdiffc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsub-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsubc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vbinary_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vbinary/gen/f32-vadd-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vaddc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vdiv-scalar-u2.c",
++        "src/src/f32-vbinary/gen/f32-vdivc-scalar-u2.c",
++        "src/src/f32-vbinary/gen/f32-vmax-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmaxc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmin-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vminc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmul-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vmulc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vprelu-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vpreluc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vrdivc-scalar-u2.c",
++        "src/src/f32-vbinary/gen/f32-vrpreluc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vrsubc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsqrdiff-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsqrdiffc-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsub-scalar-u8.c",
++        "src/src/f32-vbinary/gen/f32-vsubc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vclamp_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vclamp/gen/f32-vclamp-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vclamp_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vclamp/gen/f32-vclamp-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vcmul_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vcmul/gen/f32-vcmul-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vcmul_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vcmul/gen/f32-vcmul-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vcopysign_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vcopysign/gen/f32-vcopysign-scalar.c",
++        "src/src/f32-vcopysign/gen/f32-vcopysignc-scalar.c",
++        "src/src/f32-vcopysign/gen/f32-vrcopysignc-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vcopysign_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vcopysign/gen/f32-vcopysign-scalar.c",
++        "src/src/f32-vcopysign/gen/f32-vcopysignc-scalar.c",
++        "src/src/f32-vcopysign/gen/f32-vrcopysignc-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vcos_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vcos/gen/f32-vcos-scalar-rational-5-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vcos_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vcos/gen/f32-vcos-scalar-rational-5-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-velu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-velu/gen/f32-velu-scalar-rr2-lut16-p3-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-velu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-velu/gen/f32-velu-scalar-rr2-lut16-p3-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vexp_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vexp/gen/f32-vexp-scalar-rational-3-2-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vexp_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vexp/gen/f32-vexp-scalar-rational-3-2-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vgelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vgelu/gen/f32-vgelu-scalar-rational-12-10-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vgelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vgelu/gen/f32-vgelu-scalar-rational-12-10-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vhswish_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vhswish/gen/f32-vhswish-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vhswish_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vhswish/gen/f32-vhswish-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vlog_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vlog/gen/f32-vlog-scalar-rational-3-3-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vlog_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vlog/gen/f32-vlog-scalar-rational-3-3-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vlrelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vlrelu/gen/f32-vlrelu-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vlrelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vlrelu/gen/f32-vlrelu-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vmulcaddc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vmulcaddc/gen/f32-vmulcaddc-c1-minmax-scalar-2x.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vmulcaddc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vmulcaddc/gen/f32-vmulcaddc-c1-minmax-scalar-2x.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vrnd_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vrnd/gen/f32-vrndd-scalar-libm-u1.c",
++        "src/src/f32-vrnd/gen/f32-vrndne-scalar-libm-u1.c",
++        "src/src/f32-vrnd/gen/f32-vrndu-scalar-libm-u1.c",
++        "src/src/f32-vrnd/gen/f32-vrndz-scalar-libm-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vrnd_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vrnd/gen/f32-vrndd-scalar-libm-u1.c",
++        "src/src/f32-vrnd/gen/f32-vrndne-scalar-libm-u1.c",
++        "src/src/f32-vrnd/gen/f32-vrndu-scalar-libm-u1.c",
++        "src/src/f32-vrnd/gen/f32-vrndz-scalar-libm-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vrsqrt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vrsqrt/gen/f32-vrsqrt-scalar-rsqrt-u1.c",
++        "src/src/f32-vrsqrt/gen/f32-vrsqrt-scalar-sqrt.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vrsqrt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vrsqrt/gen/f32-vrsqrt-scalar-rsqrt-u1.c",
++        "src/src/f32-vrsqrt/gen/f32-vrsqrt-scalar-sqrt.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vsigmoid_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vsigmoid/gen/f32-vsigmoid-scalar-rr2-lut64-p2-div-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vsigmoid_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vsigmoid/gen/f32-vsigmoid-scalar-rr2-lut64-p2-div-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vsin_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vsin/gen/f32-vsin-scalar-rational-5-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vsin_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vsin/gen/f32-vsin-scalar-rational-5-4-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vsqrt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vsqrt/gen/f32-vsqrt-scalar-sqrt.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vsqrt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vsqrt/gen/f32-vsqrt-scalar-sqrt.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vtanh_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vtanh/gen/f32-vtanh-scalar-rational-9-8-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vtanh_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vtanh/gen/f32-vtanh-scalar-rational-9-8-div.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("f32-vunary_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vunary/gen/f32-vabs-scalar.c",
++        "src/src/f32-vunary/gen/f32-vneg-scalar.c",
++        "src/src/f32-vunary/gen/f32-vsqr-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("f32-vunary_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/f32-vunary/gen/f32-vabs-scalar.c",
++        "src/src/f32-vunary/gen/f32-vneg-scalar.c",
++        "src/src/f32-vunary/gen/f32-vsqr-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
 +    source_set("operators_loong64") {
 +      cflags = []
 +
@@ -16522,35 +19881,6 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/th
 +        "src/src/operators/transpose-nd.c",
 +        "src/src/operators/unary-elementwise-nc.c",
 +        "src/src/operators/unpooling-nhwc.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("enums_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/enums/allocation-type.c",
-+        "src/src/enums/datatype-strings.c",
-+        "src/src/enums/microkernel-type.c",
-+        "src/src/enums/node-type.c",
-+        "src/src/enums/operator-type.c",
 +      ]
 +
 +      configs -= [ "//build/config/compiler:chromium_code" ]
@@ -16619,24 +19949,3881 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/th
 +    }
 +  }
 +
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("enums_loong64_standalone") {
++  if (build_with_chromium) {
++    source_set("qd8-f32-qb4w-gemm_loong64") {
 +      cflags = []
 +
 +      sources = [
 +        "src/include/xnnpack.h",
-+        "src/src/enums/allocation-type.c",
-+        "src/src/enums/datatype-strings.c",
-+        "src/src/enums/microkernel-type.c",
-+        "src/src/enums/node-type.c",
-+        "src/src/enums/operator-type.c",
++        "src/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4-minmax-scalar.c",
 +      ]
 +
 +      configs -= [ "//build/config/compiler:chromium_code" ]
-       configs += [ "//build/config/compiler:no_chromium_code" ]
-       configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-       configs += [ ":xnnpack_private_config" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qd8-f32-qb4w-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qd8-f32-qc4w-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qd8-f32-qc4w-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qd8-f32-qc8w-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-1x2-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qd8-f32-qc8w-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-1x2-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qd8-f32-qc8w-igemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-1x2-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qd8-f32-qc8w-igemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-1x2-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-1x4-minmax-scalar.c",
++        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-4x4-minmax-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-dwconv_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-dwconv_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-dwconv/gen/qs8-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-f32-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-f32-vcvt/gen/qs8-f32-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-f32-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-f32-vcvt/gen/qs8-f32-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-packw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-packw/gen/qs8-packw-x16c8-gemm-goi-scalar.c",
++        "src/src/qs8-packw/gen/qs8-packw-x4c8-gemm-gio-scalar.c",
++        "src/src/qs8-packw/gen/qs8-packw-x4c8-gemm-goi-scalar.c",
++        "src/src/qs8-packw/gen/qs8-packw-x8c8-gemm-gio-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-packw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-packw/gen/qs8-packw-x16c8-gemm-goi-scalar.c",
++        "src/src/qs8-packw/gen/qs8-packw-x4c8-gemm-gio-scalar.c",
++        "src/src/qs8-packw/gen/qs8-packw-x4c8-gemm-goi-scalar.c",
++        "src/src/qs8-packw/gen/qs8-packw-x8c8-gemm-gio-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-qc4w-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc4w-gemm/gen/qs8-qc4w-gemm-1x4-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc4w-gemm/gen/qs8-qc4w-gemm-3x4-minmax-fp32-scalar-fmagic.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-qc4w-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc4w-gemm/gen/qs8-qc4w-gemm-1x4-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc4w-gemm/gen/qs8-qc4w-gemm-3x4-minmax-fp32-scalar-fmagic.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-qc8w-dwconv_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-qc8w-dwconv_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-qc8w-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc8w-gemm/gen/qs8-qc8w-gemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-gemm/gen/qs8-qc8w-gemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-qc8w-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc8w-gemm/gen/qs8-qc8w-gemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-gemm/gen/qs8-qc8w-gemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-qc8w-igemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc8w-igemm/gen/qs8-qc8w-igemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-igemm/gen/qs8-qc8w-igemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-qc8w-igemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qc8w-igemm/gen/qs8-qc8w-igemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qs8-qc8w-igemm/gen/qs8-qc8w-igemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-qu8-packw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qu8-packw/gen/qs8-qu8-packw-x16c8-gemm-goi-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-qu8-packw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-qu8-packw/gen/qs8-qu8-packw-x16c8-gemm-goi-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-rdsum_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-rdsum/gen/qs8-rdsum-minmax-fp32-scalar-u1-acc1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-rdsum_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-rdsum/gen/qs8-rdsum-minmax-fp32-scalar-u1-acc1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-rsum_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-rsum/gen/qs8-rsum-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-rsum_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-rsum/gen/qs8-rsum-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vadd_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vadd/gen/qs8-vadd-minmax-scalar-u1.c",
++        "src/src/qs8-vadd/gen/qs8-vadd-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vadd_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vadd/gen/qs8-vadd-minmax-scalar-u1.c",
++        "src/src/qs8-vadd/gen/qs8-vadd-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vaddc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vaddc/gen/qs8-vaddc-minmax-scalar-u1.c",
++        "src/src/qs8-vaddc/gen/qs8-vaddc-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vaddc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vaddc/gen/qs8-vaddc-minmax-scalar-u1.c",
++        "src/src/qs8-vaddc/gen/qs8-vaddc-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vcvt/gen/qs8-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vcvt/gen/qs8-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vlrelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vlrelu/gen/qs8-vlrelu-scalar-andxor-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vlrelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vlrelu/gen/qs8-vlrelu-scalar-andxor-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vmul_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vmul/gen/qs8-vmul-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vmul_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vmul/gen/qs8-vmul-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vmulc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vmulc/gen/qs8-vmulc-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vmulc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vmulc/gen/qs8-vmulc-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vprelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vprelu/gen/qs8-vprelu-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vprelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vprelu/gen/qs8-vprelu-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vpreluc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vpreluc/gen/qs8-vpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vpreluc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vpreluc/gen/qs8-vpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qs8-vrpreluc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vrpreluc/gen/qs8-vrpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qs8-vrpreluc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qs8-vrpreluc/gen/qs8-vrpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-dwconv_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-dwconv_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
++        "src/src/qu8-dwconv/gen/qu8-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-f32-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-f32-vcvt/gen/qu8-f32-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-f32-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-f32-vcvt/gen/qu8-f32-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-gemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-gemm/gen/qu8-gemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qu8-gemm/gen/qu8-gemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-gemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-gemm/gen/qu8-gemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qu8-gemm/gen/qu8-gemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-igemm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-igemm/gen/qu8-igemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qu8-igemm/gen/qu8-igemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-igemm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-igemm/gen/qu8-igemm-1x4-minmax-fp32-scalar-lrintf.c",
++        "src/src/qu8-igemm/gen/qu8-igemm-3x4-minmax-fp32-scalar-lrintf.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-rdsum_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-rdsum/gen/qu8-rdsum-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-rdsum_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-rdsum/gen/qu8-rdsum-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-rsum_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-rsum/gen/qu8-rsum-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-rsum_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-rsum/gen/qu8-rsum-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vadd_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vadd/gen/qu8-vadd-minmax-scalar-u1.c",
++        "src/src/qu8-vadd/gen/qu8-vadd-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vadd_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vadd/gen/qu8-vadd-minmax-scalar-u1.c",
++        "src/src/qu8-vadd/gen/qu8-vadd-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vaddc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vaddc/gen/qu8-vaddc-minmax-scalar-u1.c",
++        "src/src/qu8-vaddc/gen/qu8-vaddc-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vaddc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vaddc/gen/qu8-vaddc-minmax-scalar-u1.c",
++        "src/src/qu8-vaddc/gen/qu8-vaddc-minmax-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vcvt_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vcvt/gen/qu8-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vcvt_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vcvt/gen/qu8-vcvt-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vlrelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vlrelu/gen/qu8-vlrelu-scalar-andxor-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vlrelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vlrelu/gen/qu8-vlrelu-scalar-andxor-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vmul_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vmul/gen/qu8-vmul-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vmul_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vmul/gen/qu8-vmul-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vmulc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vmulc/gen/qu8-vmulc-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vmulc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vmulc/gen/qu8-vmulc-minmax-fp32-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vprelu_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vprelu/gen/qu8-vprelu-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vprelu_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vprelu/gen/qu8-vprelu-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vpreluc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vpreluc/gen/qu8-vpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vpreluc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vpreluc/gen/qu8-vpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("qu8-vrpreluc_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vrpreluc/gen/qu8-vrpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("qu8-vrpreluc_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/qu8-vrpreluc/gen/qu8-vrpreluc-scalar-u8.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("reference_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/reference/binary-elementwise.cc",
++        "src/src/reference/packing.cc",
++        "src/src/reference/unary-elementwise.cc",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("reference_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/reference/binary-elementwise.cc",
++        "src/src/reference/packing.cc",
++        "src/src/reference/unary-elementwise.cc",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("s8-ibilinear_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-ibilinear/gen/s8-ibilinear-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("s8-ibilinear_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-ibilinear/gen/s8-ibilinear-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("s8-maxpool_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-maxpool/gen/s8-maxpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("s8-maxpool_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-maxpool/gen/s8-maxpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("s8-rdminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-rdminmax/gen/s8-rdmax-2p2x-scalar-u2.c",
++        "src/src/s8-rdminmax/gen/s8-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("s8-rdminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-rdminmax/gen/s8-rdmax-2p2x-scalar-u2.c",
++        "src/src/s8-rdminmax/gen/s8-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("s8-rminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-rminmax/gen/s8-rmax-scalar-u2-acc2.c",
++        "src/src/s8-rminmax/gen/s8-rmin-scalar-u2-acc2.c",
++        "src/src/s8-rminmax/gen/s8-rminmax-scalar-u2-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("s8-rminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-rminmax/gen/s8-rmax-scalar-u2-acc2.c",
++        "src/src/s8-rminmax/gen/s8-rmin-scalar-u2-acc2.c",
++        "src/src/s8-rminmax/gen/s8-rminmax-scalar-u2-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("s8-vclamp_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-vclamp/s8-vclamp-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("s8-vclamp_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/s8-vclamp/s8-vclamp-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("subgraph_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/subgraph/argmax-pooling-2d.c",
++        "src/src/subgraph/average-pooling-2d.c",
++        "src/src/subgraph/batch-matrix-multiply.c",
++        "src/src/subgraph/binary.c",
++        "src/src/subgraph/concatenate.c",
++        "src/src/subgraph/convolution-2d.c",
++        "src/src/subgraph/copy.c",
++        "src/src/subgraph/deconvolution-2d.c",
++        "src/src/subgraph/deprecated.c",
++        "src/src/subgraph/depth-to-space-2d.c",
++        "src/src/subgraph/depthwise-convolution-2d.c",
++        "src/src/subgraph/even-split.c",
++        "src/src/subgraph/fully-connected-sparse.c",
++        "src/src/subgraph/fully-connected.c",
++        "src/src/subgraph/max-pooling-2d.c",
++        "src/src/subgraph/pack-lh.c",
++        "src/src/subgraph/reshape-helpers.c",
++        "src/src/subgraph/rope.c",
++        "src/src/subgraph/softmax.c",
++        "src/src/subgraph/space-to-depth-2d.c",
++        "src/src/subgraph/static-constant-pad.c",
++        "src/src/subgraph/static-reduce.c",
++        "src/src/subgraph/static-resize-bilinear-2d.c",
++        "src/src/subgraph/static-slice.c",
++        "src/src/subgraph/static-transpose.c",
++        "src/src/subgraph/subgraph-utils.c",
++        "src/src/subgraph/unary.c",
++        "src/src/subgraph/unpooling-2d.c",
++        "src/src/subgraph/validation.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("subgraph_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/subgraph/argmax-pooling-2d.c",
++        "src/src/subgraph/average-pooling-2d.c",
++        "src/src/subgraph/batch-matrix-multiply.c",
++        "src/src/subgraph/binary.c",
++        "src/src/subgraph/concatenate.c",
++        "src/src/subgraph/convolution-2d.c",
++        "src/src/subgraph/copy.c",
++        "src/src/subgraph/deconvolution-2d.c",
++        "src/src/subgraph/deprecated.c",
++        "src/src/subgraph/depth-to-space-2d.c",
++        "src/src/subgraph/depthwise-convolution-2d.c",
++        "src/src/subgraph/even-split.c",
++        "src/src/subgraph/fully-connected-sparse.c",
++        "src/src/subgraph/fully-connected.c",
++        "src/src/subgraph/max-pooling-2d.c",
++        "src/src/subgraph/pack-lh.c",
++        "src/src/subgraph/reshape-helpers.c",
++        "src/src/subgraph/rope.c",
++        "src/src/subgraph/softmax.c",
++        "src/src/subgraph/space-to-depth-2d.c",
++        "src/src/subgraph/static-constant-pad.c",
++        "src/src/subgraph/static-reduce.c",
++        "src/src/subgraph/static-resize-bilinear-2d.c",
++        "src/src/subgraph/static-slice.c",
++        "src/src/subgraph/static-transpose.c",
++        "src/src/subgraph/subgraph-utils.c",
++        "src/src/subgraph/unary.c",
++        "src/src/subgraph/unpooling-2d.c",
++        "src/src/subgraph/validation.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("tables_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/tables/exp2-k-over-2048.c",
++        "src/src/tables/exp2-k-over-64.c",
++        "src/src/tables/exp2minus-k-over-16.c",
++        "src/src/tables/exp2minus-k-over-2048.c",
++        "src/src/tables/exp2minus-k-over-32.c",
++        "src/src/tables/exp2minus-k-over-4.c",
++        "src/src/tables/exp2minus-k-over-64.c",
++        "src/src/tables/exp2minus-k-over-8.c",
++        "src/src/tables/vlog.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("tables_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/tables/exp2-k-over-2048.c",
++        "src/src/tables/exp2-k-over-64.c",
++        "src/src/tables/exp2minus-k-over-16.c",
++        "src/src/tables/exp2minus-k-over-2048.c",
++        "src/src/tables/exp2minus-k-over-32.c",
++        "src/src/tables/exp2minus-k-over-4.c",
++        "src/src/tables/exp2minus-k-over-64.c",
++        "src/src/tables/exp2minus-k-over-8.c",
++        "src/src/tables/vlog.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("u8-ibilinear_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-ibilinear/gen/u8-ibilinear-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("u8-ibilinear_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-ibilinear/gen/u8-ibilinear-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("u8-lut32norm_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-lut32norm/u8-lut32norm-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("u8-lut32norm_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-lut32norm/u8-lut32norm-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("u8-maxpool_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-maxpool/gen/u8-maxpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("u8-maxpool_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-maxpool/gen/u8-maxpool-9p-minmax-scalar-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("u8-rdminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-rdminmax/gen/u8-rdmax-2p2x-scalar-u2.c",
++        "src/src/u8-rdminmax/gen/u8-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("u8-rdminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-rdminmax/gen/u8-rdmax-2p2x-scalar-u2.c",
++        "src/src/u8-rdminmax/gen/u8-rdmin-2p2x-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("u8-rminmax_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-rminmax/gen/u8-rmax-scalar-u2-acc2.c",
++        "src/src/u8-rminmax/gen/u8-rmin-scalar-u2-acc2.c",
++        "src/src/u8-rminmax/gen/u8-rminmax-scalar-u2-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("u8-rminmax_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-rminmax/gen/u8-rmax-scalar-u2-acc2.c",
++        "src/src/u8-rminmax/gen/u8-rmin-scalar-u2-acc2.c",
++        "src/src/u8-rminmax/gen/u8-rminmax-scalar-u2-acc2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("u8-vclamp_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-vclamp/u8-vclamp-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("u8-vclamp_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/u8-vclamp/u8-vclamp-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x16-transposec_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x16-transposec/gen/x16-transposec-2x4-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x16-transposec_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x16-transposec/gen/x16-transposec-2x4-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x16-x32-packw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x16-x32-packw/gen/x16-x32-packw-x32c2-gemm-gio-scalar.c",
++        "src/src/x16-x32-packw/gen/x16-x32-packw-x32c2-gemm-goi-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x16-x32-packw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x16-x32-packw/gen/x16-x32-packw-x32c2-gemm-gio-scalar.c",
++        "src/src/x16-x32-packw/gen/x16-x32-packw-x32c2-gemm-goi-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x24-transposec_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x24-transposec/gen/x24-transposec-1x2-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x24-transposec_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x24-transposec/gen/x24-transposec-1x2-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x32-packw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x32-packw/gen/x32-packw-x2-gemm-gio-scalar.c",
++        "src/src/x32-packw/gen/x32-packw-x2-gemm-goi-scalar-float-u4.c",
++        "src/src/x32-packw/gen/x32-packw-x32-gemm-goi-scalar-int-u2.c",
++        "src/src/x32-packw/gen/x32-packw-x4-gemm-gio-scalar.c",
++        "src/src/x32-packw/gen/x32-packw-x4-gemm-goi-scalar-float-u4.c",
++        "src/src/x32-packw/gen/x32-packw-x64-gemm-goi-scalar-int-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x32-packw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x32-packw/gen/x32-packw-x2-gemm-gio-scalar.c",
++        "src/src/x32-packw/gen/x32-packw-x2-gemm-goi-scalar-float-u4.c",
++        "src/src/x32-packw/gen/x32-packw-x32-gemm-goi-scalar-int-u2.c",
++        "src/src/x32-packw/gen/x32-packw-x4-gemm-gio-scalar.c",
++        "src/src/x32-packw/gen/x32-packw-x4-gemm-goi-scalar-float-u4.c",
++        "src/src/x32-packw/gen/x32-packw-x64-gemm-goi-scalar-int-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x32-transposec_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x32-transposec/gen/x32-transposec-2x4-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x32-transposec_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x32-transposec/gen/x32-transposec-2x4-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x32-unpool_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x32-unpool/x32-unpool-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x32-unpool_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x32-unpool/x32-unpool-scalar.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x64-transposec_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x64-transposec/gen/x64-transposec-4x2-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x64-transposec_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x64-transposec/gen/x64-transposec-4x2-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x8-lut_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-lut/gen/x8-lut-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x8-lut_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-lut/gen/x8-lut-scalar-u4.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x8-packq_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-packq/x8-packq-scalar-f32qp8-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x8-packq_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-packq/x8-packq-scalar-f32qp8-u1.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x8-packw_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-packw/gen/x8-packw-x16-gemm-goi-scalar-u2.c",
++        "src/src/x8-packw/gen/x8-packw-x32-gemm-goi-scalar-u2.c",
++        "src/src/x8-packw/gen/x8-packw-x4-gemm-goi-scalar-u2.c",
++        "src/src/x8-packw/gen/x8-packw-x8-gemm-goi-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x8-packw_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-packw/gen/x8-packw-x16-gemm-goi-scalar-u2.c",
++        "src/src/x8-packw/gen/x8-packw-x32-gemm-goi-scalar-u2.c",
++        "src/src/x8-packw/gen/x8-packw-x4-gemm-goi-scalar-u2.c",
++        "src/src/x8-packw/gen/x8-packw-x8-gemm-goi-scalar-u2.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("x8-transposec_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-transposec/gen/x8-transposec-2x4-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("x8-transposec_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/x8-transposec/gen/x8-transposec-2x4-scalar-int.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("xx-copy_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-copy/xx-copy-scalar-memcpy.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("xx-copy_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-copy/xx-copy-scalar-memcpy.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("xx-fill_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-fill/xx-fill-scalar-u16.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("xx-fill_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-fill/xx-fill-scalar-u16.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("xx-pad_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-pad/xx-pad-p4-scalar-u16.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("xx-pad_loong64_standalone") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-pad/xx-pad-p4-scalar-u16.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool:pthreadpool_standalone",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++
++      if (!(is_android && use_order_profiling)) {
++        assert_no_deps = [ "//base" ]
++      }
++    }
++  }
++
++  if (build_with_chromium) {
++    source_set("xx-transposev_loong64") {
++      cflags = []
++
++      sources = [
++        "src/include/xnnpack.h",
++        "src/src/xx-transposev/xx-transposev-1x1-scalar-memcpy.c",
++      ]
++
++      configs -= [ "//build/config/compiler:chromium_code" ]
++      configs += [ "//build/config/compiler:no_chromium_code" ]
++      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
++      configs += [ ":xnnpack_private_config" ]
++
++      deps = [
++        "//third_party/cpuinfo",
++        "//third_party/fp16",
++        "//third_party/fxdiv",
++        "//third_party/pthreadpool",
++      ]
++
++      public_configs = [ ":xnnpack_public_config" ]
++    }
++  }
++
++  # This is a target that cannot depend on //base.
++  if (build_with_internal_optimization_guide) {
++    source_set("xx-transposev_loong64_standalone") {
++      cflags = []
++
++      sources = [
+         "src/include/xnnpack.h",
+         "src/src/xx-transposev/xx-transposev-1x1-scalar-memcpy.c",
+       ]
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/xnnpack/bazelroot/BUILD b/third_party/xnnpack/bazelroot/BUILD
+--- a/third_party/xnnpack/bazelroot/BUILD	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/xnnpack/bazelroot/BUILD	2000-01-01 00:00:00.000000000 +0800
+@@ -29,6 +29,19 @@ platform(
+     ],
+ )
+ 
++constraint_value(
++    name = "loongarch64",
++    constraint_setting = "@platforms//cpu:cpu",
++)
++
++platform(
++    name = "linux_loongarch64",
++    constraint_values = [
++        "@platforms//os:linux",
++        ":loongarch64",
++    ],
++)
++
+ # A dummy clang toolchain for building them for any arch.
+ 
+ filegroup(name = "empty")
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/xnnpack/generate_build_gn.py b/third_party/xnnpack/generate_build_gn.py
+--- a/third_party/xnnpack/generate_build_gn.py	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/xnnpack/generate_build_gn.py	2000-01-01 00:00:00.000000000 +0800
+@@ -239,7 +239,10 @@ _PLATFORMS = [
+               bazel_platform='//:linux_aarch64'),
+     _Platform(gn_cpu='riscv64',
+               bazel_cpu='riscv64',
+-              bazel_platform='//:linux_riscv64')
++              bazel_platform='//:linux_riscv64'),
++_Platform(gn_cpu='loong64',
++              bazel_cpu='loongarch64',
++              bazel_platform='//:linux_loongarch64')
+ ]
+ 
+ 
+@@ -352,7 +355,7 @@ def _run_bazel_cmd(args: list[str]) -> s
+       Exception if the command failed.
+     """
+     # Use standard Bazel install instead of the one included with depot_tools.
+-    exec_path = "/usr/bin/bazel"
++    exec_path = os.getenv("BAZEL_PATH_OVERRIDE") or "/usr/bin/bazel"
+     if not exec_path:
+         raise Exception(
+             "bazel is not installed. Please run `sudo apt-get install " +
 diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/xnnpack/src/src/xnnpack/common.h b/third_party/xnnpack/src/src/xnnpack/common.h
 --- a/third_party/xnnpack/src/src/xnnpack/common.h	2000-01-01 00:00:00.000000000 +0800
 +++ b/third_party/xnnpack/src/src/xnnpack/common.h	2000-01-01 00:00:00.000000000 +0800


### PR DESCRIPTION
This PR fixes the XNNPACK patches, resolving link-time "undefined XNNPACK symbol" errors that could occur in certain build environments like AOSC.

https://github.com/AOSC-Dev/aosc-os-abbs/blob/057d9a3e6a5ede7294549c52247409c1c931252d/app-web/chromium/autobuild/patches/0016-AOSCOS-third_party-xnnpack-add-LoongArch-support.patch.loongarch64